### PR TITLE
PCE-100 GitHub integration storage + security baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 # https://app.supabase.com/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,6 +32,7 @@ Goal: Import repos as drafts without auto-creating projects.
 
 ### Tickets
 
+- [x] PCE-100 GitHub integration storage + security baseline
 - [ ] PCE-101 GitHub OAuth
 - [ ] PCE-102 List & select repos (Vercel-style)
 - [ ] PCE-103 Store imported drafts

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import type { Database } from "./types";
 
@@ -32,4 +33,20 @@ export async function createClient() {
       },
     },
   );
+}
+
+export function createServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is required for server-only access.");
+  }
+
+  return createSupabaseClient<Database>(url, serviceKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
 }

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -95,6 +95,13 @@ export type Database = {
         };
         Returns: Database["public"]["Tables"]["projects"]["Row"];
       };
+      get_github_connection_state: {
+        Args: Record<string, never>;
+        Returns: {
+          connected: boolean;
+          github_login: string | null;
+        }[];
+      };
     };
     Enums: {
       [_ in never]: never;

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -3,6 +3,36 @@ import type { ProjectStatus } from "../domain/project";
 export type Database = {
   public: {
     Tables: {
+      github_connections: {
+        Row: {
+          id: string;
+          user_id: string;
+          github_user_id: number;
+          github_login: string;
+          access_token: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          github_user_id: number;
+          github_login: string;
+          access_token: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          github_user_id?: number;
+          github_login?: string;
+          access_token?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       projects: {
         Row: {
           id: string;

--- a/lib/usecases/github.ts
+++ b/lib/usecases/github.ts
@@ -1,0 +1,108 @@
+import "server-only";
+
+import { createClient } from "../supabase/server";
+import type { Database } from "../supabase/types";
+
+type GitHubConnectionRow =
+  Database["public"]["Tables"]["github_connections"]["Row"];
+
+export type GitHubConnectionState = {
+  connected: boolean;
+  githubLogin?: string;
+};
+
+function getUserIdFromClaims(claims: Record<string, unknown> | null | undefined) {
+  const sub = claims?.sub;
+  return typeof sub === "string" ? sub : null;
+}
+
+export async function getGitHubConnectionState(): Promise<GitHubConnectionState> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims) {
+    return { connected: false };
+  }
+
+  const userId = getUserIdFromClaims(data.claims);
+
+  if (!userId) {
+    return { connected: false };
+  }
+
+  const { data: connection, error: connectionError } = await supabase
+    .from("github_connections")
+    .select("github_login")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (connectionError) {
+    throw new Error(`Failed to load GitHub connection: ${connectionError.message}`);
+  }
+
+  return connection
+    ? { connected: true, githubLogin: connection.github_login }
+    : { connected: false };
+}
+
+export async function getGitHubAccessToken(): Promise<string | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims) {
+    return null;
+  }
+
+  const userId = getUserIdFromClaims(data.claims);
+
+  if (!userId) {
+    return null;
+  }
+
+  const { data: connection, error: connectionError } = await supabase
+    .from("github_connections")
+    .select("access_token")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (connectionError) {
+    throw new Error(`Failed to load GitHub token: ${connectionError.message}`);
+  }
+
+  return connection?.access_token ?? null;
+}
+
+type UpsertGitHubConnectionInput = {
+  userId: string;
+  githubUserId: number;
+  githubLogin: string;
+  accessToken: string;
+};
+
+export async function upsertGitHubConnection(
+  input: UpsertGitHubConnectionInput,
+): Promise<GitHubConnectionRow> {
+  const supabase = await createClient();
+  const now = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("github_connections")
+    .upsert(
+      {
+        user_id: input.userId,
+        github_user_id: input.githubUserId,
+        github_login: input.githubLogin,
+        access_token: input.accessToken,
+        updated_at: now,
+      },
+      { onConflict: "user_id" },
+    )
+    .select("*")
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to store GitHub connection: ${error.message}`);
+  }
+
+  return data;
+}

--- a/supabase/migrations/20250120000000_github_connections.sql
+++ b/supabase/migrations/20250120000000_github_connections.sql
@@ -1,0 +1,28 @@
+create table if not exists public.github_connections (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  github_user_id bigint not null,
+  github_login text not null,
+  access_token text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (user_id)
+);
+
+alter table public.github_connections enable row level security;
+
+create policy "github_connections_select_own"
+  on public.github_connections
+  for select
+  using (auth.uid() = user_id);
+
+create policy "github_connections_insert_own"
+  on public.github_connections
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy "github_connections_update_own"
+  on public.github_connections
+  for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/supabase/migrations/20250121000000_github_connections_server_only.sql
+++ b/supabase/migrations/20250121000000_github_connections_server_only.sql
@@ -1,0 +1,15 @@
+drop policy if exists "github_connections_select_own" on public.github_connections;
+
+create or replace function public.get_github_connection_state()
+returns table (connected boolean, github_login text)
+language sql
+security definer
+set search_path = public
+as $$
+  select (count(*) > 0) as connected,
+         max(github_login) as github_login
+    from public.github_connections
+   where user_id = auth.uid();
+$$;
+
+grant execute on function public.get_github_connection_state() to authenticated;


### PR DESCRIPTION
## Summary
- add github_connections table with RLS and migrations
- add server-only helpers to store tokens and report connection state
- mark PCE-100 complete in the roadmap

## How to test
- pnpm verify
- run Supabase migrations and confirm github_connections exists with RLS

## Risks/Notes
- tokens are stored server-side; ensure env vars are configured for Supabase auth

Closes #PCE-100