### PR TITLE
PCE-101 GitHub OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@
 # https://app.supabase.com/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-or-anon-key
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,7 @@ Goal: Import repos as drafts without auto-creating projects.
 ### Tickets
 
 - [x] PCE-100 GitHub integration storage + security baseline
-- [ ] PCE-101 GitHub OAuth
+- [x] PCE-101 GitHub OAuth
 - [ ] PCE-102 List & select repos (Vercel-style)
 - [ ] PCE-103 Store imported drafts
 - [ ] PCE-104 Convert draft → Project (manual)

--- a/app/auth/github/callback/route.ts
+++ b/app/auth/github/callback/route.ts
@@ -1,0 +1,117 @@
+import { cookies } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import { upsertGitHubConnection } from "@/lib/usecases/github";
+
+type GitHubTokenResponse = {
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+};
+
+type GitHubUserResponse = {
+  id: number;
+  login: string;
+};
+
+function getGitHubClientConfig() {
+  return {
+    clientId: process.env.GITHUB_CLIENT_ID,
+    clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  };
+}
+
+async function exchangeCodeForToken(
+  code: string,
+  redirectUri: string,
+): Promise<GitHubTokenResponse> {
+  const { clientId, clientSecret } = getGitHubClientConfig();
+
+  if (!clientId || !clientSecret) {
+    return { error: "missing_client_config" };
+  }
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    redirect_uri: redirectUri,
+  });
+
+  const response = await fetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  return (await response.json()) as GitHubTokenResponse;
+}
+
+async function fetchGitHubUser(accessToken: string): Promise<GitHubUserResponse> {
+  const response = await fetch("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch GitHub user profile.");
+  }
+
+  return (await response.json()) as GitHubUserResponse;
+}
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const redirectUri = `${url.origin}/auth/github/callback`;
+  const cookieStore = await cookies();
+  const storedState = cookieStore.get("github_oauth_state")?.value;
+
+  if (!code || !state || !storedState || state !== storedState) {
+    return NextResponse.redirect(new URL("/protected?github=state_error", url));
+  }
+
+  cookieStore.set("github_oauth_state", "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+
+  const tokenResponse = await exchangeCodeForToken(code, redirectUri);
+
+  if (!tokenResponse.access_token) {
+    return NextResponse.redirect(
+      new URL("/protected?github=token_error", url),
+    );
+  }
+
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getClaims();
+  const userId = typeof data?.claims?.sub === "string" ? data.claims.sub : null;
+
+  if (!userId) {
+    return NextResponse.redirect(new URL("/auth/login", url));
+  }
+
+  const githubUser = await fetchGitHubUser(tokenResponse.access_token);
+
+  await upsertGitHubConnection({
+    userId,
+    githubUserId: githubUser.id,
+    githubLogin: githubUser.login,
+    accessToken: tokenResponse.access_token,
+  });
+
+  return NextResponse.redirect(new URL("/protected?github=connected", url));
+}

--- a/app/auth/github/route.ts
+++ b/app/auth/github/route.ts
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+import { NextResponse, type NextRequest } from "next/server";
+
+function getGitHubClientId() {
+  return process.env.GITHUB_CLIENT_ID;
+}
+
+export async function GET(request: NextRequest) {
+  const clientId = getGitHubClientId();
+
+  if (!clientId) {
+    return NextResponse.json(
+      { error: "Missing GITHUB_CLIENT_ID" },
+      { status: 500 },
+    );
+  }
+
+  const state = crypto.randomUUID();
+  const redirectUri = `${request.nextUrl.origin}/auth/github/callback`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: "read:user repo",
+    state,
+  });
+
+  const cookieStore = await cookies();
+  cookieStore.set("github_oauth_state", state, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 600,
+  });
+
+  return NextResponse.redirect(
+    `https://github.com/login/oauth/authorize?${params.toString()}`,
+  );
+}

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -5,6 +5,7 @@ import {
   applyLifecycleAction,
   type LifecycleAction,
 } from "@/lib/usecases/projects";
+import { getGitHubConnectionState } from "@/lib/usecases/github";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
@@ -126,9 +127,24 @@ async function ProjectList() {
 
   const projects = await fetchProjects();
   const grouped = groupProjects(projects);
+  const githubConnection = await getGitHubConnectionState();
 
   return (
     <div className="flex flex-col gap-8">
+      <div className="rounded border border-border px-4 py-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="text-sm">
+            {githubConnection.connected
+              ? `GitHub connected as ${githubConnection.githubLogin}`
+              : "GitHub not connected"}
+          </div>
+          {!githubConnection.connected && (
+            <Button asChild size="sm" variant="outline">
+              <Link href="/auth/github">Connect GitHub</Link>
+            </Button>
+          )}
+        </div>
+      </div>
       <ProjectSection status="active" projects={grouped.active} />
       <ProjectSection status="frozen" projects={grouped.frozen} />
       <ProjectSection status="archived" projects={grouped.archived} />


### PR DESCRIPTION
## Summary
- add GitHub OAuth connect flow and callback
- persist GitHub connection via PCE-100 storage layer
- show connection status + Connect button on /protected
- add GitHub env vars to .env.example
- mark PCE-101 complete in the roadmap

## How to test
- pnpm verify
- set GITHUB_CLIENT_ID/GITHUB_CLIENT_SECRET
- visit /protected and click Connect GitHub
- complete OAuth, then see Connected state

## Risks/Notes
- depends on PCE-100 migration and storage layer
- uses scope: read:user repo

Closes #PCE-101