### PR TITLE
PCE-103 Store imported drafts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,5 +35,5 @@ Goal: Import repos as drafts without auto-creating projects.
 - [x] PCE-100 GitHub integration storage + security baseline
 - [x] PCE-101 GitHub OAuth
 - [x] PCE-102 List & select repos (Vercel-style)
-- [ ] PCE-103 Store imported drafts
+- [x] PCE-103 Store imported drafts
 - [ ] PCE-104 Convert draft → Project (manual)

--- a/app/protected/github/drafts/page.tsx
+++ b/app/protected/github/drafts/page.tsx
@@ -1,0 +1,83 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/lib/supabase/server";
+import { fetchRepoDrafts } from "@/lib/usecases/github-drafts";
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "—";
+  }
+
+  return new Date(value).toLocaleDateString();
+}
+
+async function DraftList() {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getClaims();
+
+  if (!data?.claims) {
+    redirect("/auth/login");
+  }
+
+  const drafts = await fetchRepoDrafts();
+
+  if (drafts.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No drafts imported yet. Import repos to see them here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {drafts.map((draft) => (
+        <div
+          key={draft.id}
+          className="rounded border border-border px-4 py-3"
+        >
+          <div className="font-medium">{draft.full_name}</div>
+          <div className="text-sm text-muted-foreground">
+            {draft.visibility} · default branch {draft.default_branch} · pushed{" "}
+            {formatDate(draft.pushed_at)}
+          </div>
+          {draft.description && (
+            <div className="text-sm text-muted-foreground">
+              {draft.description}
+            </div>
+          )}
+          {draft.converted_project_id && (
+            <div className="text-xs text-muted-foreground">
+              Converted · {formatDate(draft.converted_at)}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function DraftsPage() {
+  return (
+    <div className="flex-1 w-full flex flex-col gap-8">
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="text-2xl font-bold">Repo drafts</h1>
+          <Button asChild variant="outline">
+            <Link href="/protected/github">Back to import</Link>
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Imported repositories waiting to be converted into projects.
+        </p>
+      </header>
+
+      <Suspense>
+        <DraftList />
+      </Suspense>
+    </div>
+  );
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -33,6 +33,54 @@ export type Database = {
         };
         Relationships: [];
       };
+      repo_drafts: {
+        Row: {
+          id: string;
+          user_id: string;
+          github_repo_id: number;
+          full_name: string;
+          html_url: string;
+          description: string | null;
+          visibility: string;
+          default_branch: string;
+          pushed_at: string | null;
+          topics: string[] | null;
+          imported_at: string;
+          converted_project_id: string | null;
+          converted_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          github_repo_id: number;
+          full_name: string;
+          html_url: string;
+          description?: string | null;
+          visibility: string;
+          default_branch: string;
+          pushed_at?: string | null;
+          topics?: string[] | null;
+          imported_at?: string;
+          converted_project_id?: string | null;
+          converted_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          github_repo_id?: number;
+          full_name?: string;
+          html_url?: string;
+          description?: string | null;
+          visibility?: string;
+          default_branch?: string;
+          pushed_at?: string | null;
+          topics?: string[] | null;
+          imported_at?: string;
+          converted_project_id?: string | null;
+          converted_at?: string | null;
+        };
+        Relationships: [];
+      };
       projects: {
         Row: {
           id: string;

--- a/lib/usecases/github-drafts.ts
+++ b/lib/usecases/github-drafts.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { createClient } from "../supabase/server";
+import type { Database } from "../supabase/types";
+
+type RepoDraftRow = Database["public"]["Tables"]["repo_drafts"]["Row"];
+
+export type RepoDraftImport = {
+  github_repo_id: number;
+  full_name: string;
+  html_url: string;
+  description: string | null;
+  visibility: string;
+  default_branch: string;
+  pushed_at: string | null;
+  topics?: string[] | null;
+};
+
+function getUserIdFromClaims(claims: Record<string, unknown> | null | undefined) {
+  const sub = claims?.sub;
+  return typeof sub === "string" ? sub : null;
+}
+
+export async function upsertRepoDrafts(
+  drafts: RepoDraftImport[],
+): Promise<number> {
+  if (drafts.length === 0) {
+    return 0;
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims) {
+    throw new Error("Not authenticated.");
+  }
+
+  const userId = getUserIdFromClaims(data.claims);
+
+  if (!userId) {
+    throw new Error("Missing user id.");
+  }
+
+  const now = new Date().toISOString();
+  const payload = drafts.map((draft) => ({
+    user_id: userId,
+    github_repo_id: draft.github_repo_id,
+    full_name: draft.full_name,
+    html_url: draft.html_url,
+    description: draft.description,
+    visibility: draft.visibility,
+    default_branch: draft.default_branch,
+    pushed_at: draft.pushed_at,
+    topics: draft.topics ?? null,
+    imported_at: now,
+  }));
+
+  const { error: upsertError } = await supabase
+    .from("repo_drafts")
+    .upsert(payload, { onConflict: "user_id,github_repo_id" });
+
+  if (upsertError) {
+    throw new Error(`Failed to import drafts: ${upsertError.message}`);
+  }
+
+  return payload.length;
+}
+
+export async function fetchRepoDrafts(): Promise<RepoDraftRow[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims) {
+    throw new Error("Not authenticated.");
+  }
+
+  const { data: drafts, error: draftsError } = await supabase
+    .from("repo_drafts")
+    .select("*")
+    .order("imported_at", { ascending: false });
+
+  if (draftsError) {
+    throw new Error(`Failed to load drafts: ${draftsError.message}`);
+  }
+
+  return drafts ?? [];
+}

--- a/supabase/migrations/20250122000000_repo_drafts.sql
+++ b/supabase/migrations/20250122000000_repo_drafts.sql
@@ -1,0 +1,34 @@
+create table if not exists public.repo_drafts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  github_repo_id bigint not null,
+  full_name text not null,
+  html_url text not null,
+  description text,
+  visibility text not null,
+  default_branch text not null,
+  pushed_at timestamptz,
+  topics text[],
+  imported_at timestamptz not null default now(),
+  converted_project_id uuid references public.projects(id),
+  converted_at timestamptz,
+  unique (user_id, github_repo_id)
+);
+
+alter table public.repo_drafts enable row level security;
+
+create policy "repo_drafts_select_own"
+  on public.repo_drafts
+  for select
+  using (auth.uid() = user_id);
+
+create policy "repo_drafts_insert_own"
+  on public.repo_drafts
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy "repo_drafts_update_own"
+  on public.repo_drafts
+  for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add repo_drafts table with RLS and migrations
- persist selected repos as drafts and redirect to drafts list
- add drafts list view and mark PCE-103 complete on the roadmap

## How to test
- pnpm verify
- visit /protected/github, select repos, click Import selected
- confirm drafts show under /protected/github/drafts

## Risks/Notes
- depends on PCE-102 for the import UI
- build needs network access to fetch Google Fonts

Closes #PCE-103