### PR TITLE
PCE-104 Convert draft → Project

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,4 +36,4 @@ Goal: Import repos as drafts without auto-creating projects.
 - [x] PCE-101 GitHub OAuth
 - [x] PCE-102 List & select repos (Vercel-style)
 - [x] PCE-103 Store imported drafts
-- [ ] PCE-104 Convert draft → Project (manual)
+- [x] PCE-104 Convert draft → Project (manual)

--- a/app/protected/github/drafts/[id]/page.tsx
+++ b/app/protected/github/drafts/[id]/page.tsx
@@ -1,0 +1,170 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { createClient } from "@/lib/supabase/server";
+import {
+  convertRepoDraft,
+  fetchRepoDraftById,
+} from "@/lib/usecases/github-drafts";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+function normalizeOptional(value: FormDataEntryValue | null): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function formatDate(value: string | null) {
+  if (!value) {
+    return "—";
+  }
+
+  return new Date(value).toLocaleDateString();
+}
+
+async function handleConvertDraft(id: string, formData: FormData) {
+  "use server";
+
+  const nameValue = formData.get("name");
+  const nextActionValue = formData.get("nextAction");
+
+  if (typeof nameValue !== "string" || typeof nextActionValue !== "string") {
+    throw new Error("Name and next action are required.");
+  }
+
+  const projectId = await convertRepoDraft(id, {
+    name: nameValue.trim(),
+    nextAction: nextActionValue.trim(),
+    finishDefinition: normalizeOptional(formData.get("finishDefinition")),
+  });
+
+  redirect(`/protected/projects/${projectId}`);
+}
+
+async function DraftDetail({ id }: { id: string }) {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getClaims();
+
+  if (!data?.claims) {
+    redirect("/auth/login");
+  }
+
+  const draft = await fetchRepoDraftById(id);
+
+  if (!draft) {
+    notFound();
+  }
+
+  const converted = Boolean(draft.converted_project_id);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="rounded border border-border px-4 py-3">
+        <div className="font-medium">{draft.full_name}</div>
+        <div className="text-sm text-muted-foreground">
+          {draft.visibility} · default branch {draft.default_branch} · pushed{" "}
+          {formatDate(draft.pushed_at)}
+        </div>
+        {draft.description && (
+          <div className="text-sm text-muted-foreground">
+            {draft.description}
+          </div>
+        )}
+        <div className="text-sm text-muted-foreground">
+          Source:{" "}
+          <a
+            href={draft.html_url}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            {draft.html_url}
+          </a>
+        </div>
+      </div>
+
+      {converted ? (
+        <div className="rounded border border-border px-4 py-3 text-sm text-muted-foreground">
+          Converted on {formatDate(draft.converted_at)}.{" "}
+          <Link
+            href={`/protected/projects/${draft.converted_project_id}`}
+            className="underline"
+          >
+            View project
+          </Link>
+          .
+        </div>
+      ) : (
+        <form className="flex flex-col gap-6" action={handleConvertDraft.bind(null, id)}>
+          <div className="grid gap-2">
+            <Label htmlFor="name">Project name</Label>
+            <Input id="name" name="name" defaultValue={draft.full_name} required />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="nextAction">Next action</Label>
+            <Input id="nextAction" name="nextAction" required />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="finishDefinition">Finish definition</Label>
+            <textarea
+              id="finishDefinition"
+              name="finishDefinition"
+              className="min-h-24 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button type="submit">Convert to project</Button>
+            <span className="text-sm text-muted-foreground">
+              Project will start as Frozen.
+            </span>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+async function DraftDetailLoader({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return <DraftDetail id={id} />;
+}
+
+export default function DraftDetailPage({ params }: PageProps) {
+  return (
+    <div className="flex-1 w-full flex flex-col gap-8">
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="text-2xl font-bold">Draft detail</h1>
+          <Button asChild variant="outline">
+            <Link href="/protected/github/drafts">Back to drafts</Link>
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Convert this draft into a PCE project.
+        </p>
+      </header>
+
+      <Suspense>
+        <DraftDetailLoader params={params} />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/protected/github/drafts/page.tsx
+++ b/app/protected/github/drafts/page.tsx
@@ -39,7 +39,14 @@ async function DraftList() {
           key={draft.id}
           className="rounded border border-border px-4 py-3"
         >
-          <div className="font-medium">{draft.full_name}</div>
+          <div className="font-medium">
+            <Link
+              href={`/protected/github/drafts/${draft.id}`}
+              className="underline"
+            >
+              {draft.full_name}
+            </Link>
+          </div>
           <div className="text-sm text-muted-foreground">
             {draft.visibility} · default branch {draft.default_branch} · pushed{" "}
             {formatDate(draft.pushed_at)}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -150,6 +150,17 @@ export type Database = {
           github_login: string | null;
         }[];
       };
+      convert_repo_draft_to_project: {
+        Args: {
+          draft_id: string;
+          project_name: string;
+          next_action: string;
+          finish_definition: string | null;
+        };
+        Returns: {
+          project_id: string;
+        }[];
+      };
     };
     Enums: {
       [_ in never]: never;

--- a/lib/usecases/github-drafts.ts
+++ b/lib/usecases/github-drafts.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { createClient } from "../supabase/server";
 import type { Database } from "../supabase/types";
+import { createProject } from "./projects";
 
 type RepoDraftRow = Database["public"]["Tables"]["repo_drafts"]["Row"];
 
@@ -84,4 +85,85 @@ export async function fetchRepoDrafts(): Promise<RepoDraftRow[]> {
   }
 
   return drafts ?? [];
+}
+
+export async function fetchRepoDraftById(
+  id: string,
+): Promise<RepoDraftRow | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims) {
+    throw new Error("Not authenticated.");
+  }
+
+  const { data: draft, error: draftError } = await supabase
+    .from("repo_drafts")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (draftError) {
+    throw new Error(`Failed to load draft: ${draftError.message}`);
+  }
+
+  return draft ?? null;
+}
+
+export type RepoDraftConversionInput = {
+  name: string;
+  nextAction: string;
+  finishDefinition?: string | null;
+};
+
+export async function convertRepoDraft(
+  id: string,
+  input: RepoDraftConversionInput,
+): Promise<string> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims) {
+    throw new Error("Not authenticated.");
+  }
+
+  const draft = await fetchRepoDraftById(id);
+
+  if (!draft) {
+    throw new Error("Draft not found.");
+  }
+
+  if (draft.converted_project_id) {
+    throw new Error("Draft has already been converted.");
+  }
+
+  const project = await createProject({
+    name: input.name.trim(),
+    nextAction: input.nextAction.trim(),
+    finishDefinition: input.finishDefinition ?? null,
+    narrativeLink: draft.html_url,
+    status: "frozen",
+  });
+
+  const now = new Date().toISOString();
+  const { data: updatedDraft, error: updateError } = await supabase
+    .from("repo_drafts")
+    .update({
+      converted_project_id: project.id,
+      converted_at: now,
+    })
+    .eq("id", id)
+    .is("converted_project_id", null)
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) {
+    throw new Error(`Failed to mark draft as converted: ${updateError.message}`);
+  }
+
+  if (!updatedDraft) {
+    throw new Error("Draft was already converted.");
+  }
+
+  return project.id;
 }

--- a/supabase/migrations/20250123000000_convert_repo_draft.sql
+++ b/supabase/migrations/20250123000000_convert_repo_draft.sql
@@ -1,0 +1,70 @@
+create or replace function public.convert_repo_draft_to_project(
+  draft_id uuid,
+  project_name text,
+  next_action text,
+  finish_definition text
+)
+returns table (project_id uuid)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  draft_record public.repo_drafts;
+  trimmed_name text := btrim(project_name);
+  trimmed_next_action text := btrim(next_action);
+  new_project_id uuid;
+begin
+  if trimmed_name is null or trimmed_name = '' then
+    raise exception 'Project name is required.';
+  end if;
+
+  if trimmed_next_action is null or trimmed_next_action = '' then
+    raise exception 'Next action is required.';
+  end if;
+
+  if char_length(trimmed_next_action) > 140 then
+    raise exception 'Next action must be at most 140 characters.';
+  end if;
+
+  select * into draft_record
+    from public.repo_drafts
+    where id = draft_id
+      and user_id = auth.uid()
+      and converted_project_id is null
+    for update;
+
+  if not found then
+    raise exception 'Draft not found or already converted.';
+  end if;
+
+  insert into public.projects (
+    name,
+    narrative_link,
+    finish_definition,
+    status,
+    next_action,
+    start_date,
+    finish_date
+  )
+  values (
+    trimmed_name,
+    draft_record.html_url,
+    finish_definition,
+    'frozen',
+    trimmed_next_action,
+    null,
+    null
+  )
+  returning id into new_project_id;
+
+  update public.repo_drafts
+    set converted_project_id = new_project_id,
+        converted_at = now()
+    where id = draft_id;
+
+  return query select new_project_id as project_id;
+end;
+$$;
+
+grant execute on function public.convert_repo_draft_to_project(uuid, text, text, text) to authenticated;


### PR DESCRIPTION
## Summary
- add draft detail view with conversion form
- convert repo drafts into frozen projects using existing use-cases
- mark PCE-104 complete on the roadmap

## How to test
- pnpm verify
- import repos, visit /protected/github/drafts
- open a draft, fill name/nextAction, convert
- confirm redirect to project detail and draft marked converted

## Risks/Notes
- relies on repo_drafts RLS and existing project creation flow

Closes #PCE-104