### PR TITLE
Remove starter links from navbar

### DIFF
--- a/app/protected/layout.tsx
+++ b/app/protected/layout.tsx
@@ -1,4 +1,3 @@
-import { DeployButton } from "@/components/deploy-button";
 import { EnvVarWarning } from "@/components/env-var-warning";
 import { AuthButton } from "@/components/auth-button";
 import { ThemeSwitcher } from "@/components/theme-switcher";
@@ -17,10 +16,7 @@ export default function ProtectedLayout({
         <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
           <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
             <div className="flex gap-5 items-center font-semibold">
-              <Link href={"/"}>Next.js Supabase Starter</Link>
-              <div className="flex items-center gap-2">
-                <DeployButton />
-              </div>
+              <Link href={"/"}>PCE</Link>
             </div>
             {!hasEnvVars ? (
               <EnvVarWarning />


### PR DESCRIPTION
## Summary\n- remove Next.js Supabase Starter label and Deploy to Vercel button from protected navbar\n\n## How to test\n- visit /protected and confirm navbar no longer shows starter/deploy links\n\n## Risks/Notes\n- minimal UI text change only\n\nCloses #20