### PR TITLE
Add Epic 3 — UX & Continuity (V1) to ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,3 +38,13 @@ Goal: Import repos as drafts without auto-creating projects.
 - [x] PCE-102 List & select repos (Vercel-style)
 - [x] PCE-103 Store imported drafts
 - [x] PCE-104 Convert draft → Project (manual)
+
+## Epic 3 - UX & Continuity (V1)
+
+Goal: Improve visibility when managing many projects.
+
+### Tickets
+
+- [ ] PCE-201 Dashboard board view (columns)
+- [ ] PCE-202 Post-create redirect & feedback
+- [ ] PCE-203 Restart archived project as new cycle


### PR DESCRIPTION
### Motivation
- Capture upcoming UX and continuity scope in the project roadmap by adding Epic 3 with tickets PCE-201 through PCE-203.

### Description
- Update `ROADMAP.md` to add "Epic 3 — UX & Continuity (V1)" including goals and ticket details for `PCE-201` (dashboard board view), `PCE-202` (post-create redirects & feedback), and `PCE-203` (restart archived project as new cycle); Closes #201.

### Testing
- Documentation-only change so no automated tests were run or required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971a484a884832cae82ccedd0746a0f)