### PR TITLE
PCE-204 Delete archived projects

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,3 +48,4 @@ Goal: Improve visibility when managing many projects.
 - [ ] PCE-201 Dashboard board view (columns)
 - [ ] PCE-202 Post-create redirect & feedback
 - [ ] PCE-203 Restart archived project as new cycle
+- [ ] PCE-204 Delete archived projects (manual cleanup)

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -1,4 +1,5 @@
 import type { ProjectStatus } from "@/lib/domain/project";
+import { DeleteArchivedProjectButton } from "@/components/delete-archived-project-button";
 import { FeedbackToast } from "@/components/feedback-toast";
 import { LifecycleActionButton } from "@/components/lifecycle-action-button";
 import { RestartCycleButton } from "@/components/restart-cycle-button";
@@ -7,6 +8,7 @@ import { createClient } from "@/lib/supabase/server";
 import {
   applyLifecycleAction,
   type LifecycleAction,
+  deleteArchivedProject,
   restartArchivedProject,
 } from "@/lib/usecases/projects";
 import { getGitHubConnectionState } from "@/lib/usecases/github";
@@ -62,6 +64,12 @@ async function handleRestartCycle(id: string, nextAction: string) {
   "use server";
 
   await restartArchivedProject(id, nextAction);
+}
+
+async function handleDeleteProject(id: string) {
+  "use server";
+
+  await deleteArchivedProject(id);
 }
 
 async function fetchProjects(): Promise<ProjectRow[]> {
@@ -133,10 +141,14 @@ function ProjectColumn({
                 </div>
               )}
               {project.status === "archived" && (
-                <div className="mt-3">
+                <div className="mt-3 flex flex-wrap gap-2">
                   <RestartCycleButton
                     id={project.id}
                     onRestart={handleRestartCycle}
+                  />
+                  <DeleteArchivedProjectButton
+                    id={project.id}
+                    onDelete={handleDeleteProject}
                   />
                 </div>
               )}

--- a/components/delete-archived-project-button.tsx
+++ b/components/delete-archived-project-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+
+type DeleteArchivedProjectButtonProps = {
+  id: string;
+  onDelete: (id: string) => Promise<void>;
+};
+
+export function DeleteArchivedProjectButton({
+  id,
+  onDelete,
+}: DeleteArchivedProjectButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = () => {
+    startTransition(async () => {
+      try {
+        await onDelete(id);
+        toast.success("Project deleted.");
+        router.refresh();
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to delete project. Please try again.";
+        toast.error(message);
+      }
+    });
+  };
+
+  const confirmDelete = () => {
+    toast("Delete this archived project?", {
+      action: {
+        label: "Delete",
+        onClick: handleDelete,
+      },
+      cancel: {
+        label: "Cancel",
+      },
+    });
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="destructive"
+      size="sm"
+      disabled={isPending}
+      onClick={confirmDelete}
+    >
+      Delete
+    </Button>
+  );
+}

--- a/components/delete-archived-project-button.tsx
+++ b/components/delete-archived-project-button.tsx
@@ -42,6 +42,7 @@ export function DeleteArchivedProjectButton({
       },
       cancel: {
         label: "Cancel",
+        onClick: () => {},
       },
     });
   };

--- a/lib/usecases/projects.ts
+++ b/lib/usecases/projects.ts
@@ -293,3 +293,38 @@ export async function restartArchivedProject(
 
   return toProject(data);
 }
+
+export async function deleteArchivedProject(id: string): Promise<void> {
+  if (!id) {
+    throw new Error("Project id is required.");
+  }
+
+  const project = await fetchProjectById(id);
+
+  if (!project) {
+    throw new Error("Project not found.");
+  }
+
+  if (project.status !== "archived") {
+    throw new Error("Only archived projects can be deleted.");
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("projects")
+    .delete()
+    .eq("id", id)
+    .eq("status", "archived")
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to delete project: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(
+      "Project status changed before deletion; please refresh and try again.",
+    );
+  }
+}

--- a/supabase/migrations/20250124000000_repo_drafts_on_delete_set_null.sql
+++ b/supabase/migrations/20250124000000_repo_drafts_on_delete_set_null.sql
@@ -1,0 +1,8 @@
+alter table public.repo_drafts
+  drop constraint if exists repo_drafts_converted_project_id_fkey;
+
+alter table public.repo_drafts
+  add constraint repo_drafts_converted_project_id_fkey
+  foreign key (converted_project_id)
+  references public.projects(id)
+  on delete set null;


### PR DESCRIPTION
## What
- Add a Sonner confirmation toast before deleting archived projects
- Enforce server-side checks to delete only archived projects
- Add a roadmap ticket for PCE-204

## Why
- Allow cleanup of demo/test projects while protecting active work

## How to test
- Archive a project
- Click "Delete" and confirm in the Sonner toast
- Verify the project is removed and other statuses cannot be deleted

## Risks
- Accidental deletion if users confirm the toast

## Screenshots
- N/A

Closes #PCE-204