### PR TITLE
PCE-401 Snapshots on Freeze/Finish

### DIFF
--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -3,6 +3,11 @@ import { DeleteArchivedProjectButton } from "@/components/delete-archived-projec
 import { FeedbackToast } from "@/components/feedback-toast";
 import { LifecycleActionButton } from "@/components/lifecycle-action-button";
 import { RestartCycleButton } from "@/components/restart-cycle-button";
+import {
+  SnapshotActionButton,
+  type SnapshotAction,
+  type SnapshotInput,
+} from "@/components/snapshot-action-button";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/server";
 import {
@@ -48,6 +53,8 @@ const ACTION_LABELS: Record<LifecycleAction, string> = {
   finish: "Finish",
 };
 
+const SNAPSHOT_ACTIONS = new Set<LifecycleAction>(["freeze", "finish"]);
+
 const ACTIONS_BY_STATUS: Record<ProjectStatus, LifecycleAction[]> = {
   active: ["freeze", "archive", "finish"],
   frozen: ["launch", "archive", "finish"],
@@ -58,6 +65,16 @@ async function handleLifecycleAction(id: string, action: LifecycleAction) {
   "use server";
 
   await applyLifecycleAction(id, action);
+}
+
+async function handleSnapshotAction(
+  id: string,
+  action: SnapshotAction,
+  snapshot: SnapshotInput,
+) {
+  "use server";
+
+  await applyLifecycleAction(id, action, snapshot);
 }
 
 async function handleRestartCycle(id: string, nextAction: string) {
@@ -130,12 +147,21 @@ function ProjectColumn({
                 <div className="mt-3 flex flex-wrap gap-2">
                   {ACTIONS_BY_STATUS[project.status].map((action) => (
                     <div key={action}>
-                      <LifecycleActionButton
-                        id={project.id}
-                        action={action}
-                        label={ACTION_LABELS[action]}
-                        onAction={handleLifecycleAction}
-                      />
+                      {SNAPSHOT_ACTIONS.has(action) ? (
+                        <SnapshotActionButton
+                          id={project.id}
+                          action={action as SnapshotAction}
+                          label={ACTION_LABELS[action]}
+                          onAction={handleSnapshotAction}
+                        />
+                      ) : (
+                        <LifecycleActionButton
+                          id={project.id}
+                          action={action}
+                          label={ACTION_LABELS[action]}
+                          onAction={handleLifecycleAction}
+                        />
+                      )}
                     </div>
                   ))}
                 </div>

--- a/components/snapshot-action-button.tsx
+++ b/components/snapshot-action-button.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export type SnapshotAction = "freeze" | "finish";
+
+export type SnapshotInput = {
+  summary: string;
+  label?: string | null;
+  leftOut?: string | null;
+  futureNote?: string | null;
+};
+
+type SnapshotActionButtonProps = {
+  id: string;
+  action: SnapshotAction;
+  label: string;
+  onAction: (id: string, action: SnapshotAction, snapshot: SnapshotInput) => Promise<void>;
+};
+
+export function SnapshotActionButton({
+  id,
+  action,
+  label,
+  onAction,
+}: SnapshotActionButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [isOpen, setIsOpen] = useState(false);
+  const [summary, setSummary] = useState("");
+  const [snapshotLabel, setSnapshotLabel] = useState("");
+  const [leftOut, setLeftOut] = useState("");
+  const [futureNote, setFutureNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const summaryId = `snapshot-summary-${id}-${action}`;
+
+  const closeDialog = () => {
+    setIsOpen(false);
+    setSummary("");
+    setSnapshotLabel("");
+    setLeftOut("");
+    setFutureNote("");
+    setError(null);
+  };
+
+  const handleConfirm = () => {
+    const trimmedSummary = summary.trim();
+
+    if (!trimmedSummary) {
+      setError("Summary is required.");
+      return;
+    }
+
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        await onAction(id, action, {
+          summary: trimmedSummary,
+          label: snapshotLabel.trim() || null,
+          leftOut: leftOut.trim() || null,
+          futureNote: futureNote.trim() || null,
+        });
+        closeDialog();
+        router.refresh();
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to update project. Please try again.";
+        toast.error(message);
+      }
+    });
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={isPending}
+        onClick={() => setIsOpen(true)}
+      >
+        {label}
+      </Button>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={closeDialog}
+        >
+          <div
+            className="w-full max-w-lg rounded-lg border border-border bg-background p-5 shadow-lg"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="text-lg font-semibold">
+              {action === "freeze" ? "Freeze project" : "Finish project"}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Capture a short snapshot before you {action}.
+            </p>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={summaryId}>Summary</Label>
+              <textarea
+                id={summaryId}
+                name="summary"
+                value={summary}
+                onChange={(event) => setSummary(event.target.value)}
+                className="min-h-24 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+              {error && <p className="text-sm text-destructive">{error}</p>}
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-label`}>Label (optional)</Label>
+              <Input
+                id={`${summaryId}-label`}
+                name="label"
+                value={snapshotLabel}
+                onChange={(event) => setSnapshotLabel(event.target.value)}
+              />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-left-out`}>Left out (optional)</Label>
+              <textarea
+                id={`${summaryId}-left-out`}
+                name="leftOut"
+                value={leftOut}
+                onChange={(event) => setLeftOut(event.target.value)}
+                className="min-h-20 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-future-note`}>
+                Future note (optional)
+              </Label>
+              <textarea
+                id={`${summaryId}-future-note`}
+                name="futureNote"
+                value={futureNote}
+                onChange={(event) => setFutureNote(event.target.value)}
+                className="min-h-20 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeDialog}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleConfirm}
+                disabled={isPending || summary.trim().length === 0}
+              >
+                {action === "freeze" ? "Freeze" : "Finish"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -33,11 +33,11 @@ export type Database = {
         };
         Relationships: [];
       };
-      repo_drafts: {
-        Row: {
-          id: string;
-          user_id: string;
-          github_repo_id: number;
+        repo_drafts: {
+          Row: {
+            id: string;
+            user_id: string;
+            github_repo_id: number;
           full_name: string;
           html_url: string;
           description: string | null;
@@ -78,13 +78,46 @@ export type Database = {
           imported_at?: string;
           converted_project_id?: string | null;
           converted_at?: string | null;
+          };
+          Relationships: [];
         };
-        Relationships: [];
-      };
-      projects: {
-        Row: {
-          id: string;
-          name: string;
+        project_snapshots: {
+          Row: {
+            id: string;
+            project_id: string;
+            kind: string;
+            label: string | null;
+            summary: string;
+            left_out: string | null;
+            future_note: string | null;
+            created_at: string;
+          };
+          Insert: {
+            id?: string;
+            project_id: string;
+            kind: string;
+            label?: string | null;
+            summary: string;
+            left_out?: string | null;
+            future_note?: string | null;
+            created_at?: string;
+          };
+          Update: {
+            id?: string;
+            project_id?: string;
+            kind?: string;
+            label?: string | null;
+            summary?: string;
+            left_out?: string | null;
+            future_note?: string | null;
+            created_at?: string;
+          };
+          Relationships: [];
+        };
+        projects: {
+          Row: {
+            id: string;
+            name: string;
           narrative_link: string | null;
           why_now: string | null;
           finish_definition: string | null;
@@ -136,17 +169,37 @@ export type Database = {
         };
         Returns: Database["public"]["Tables"]["projects"]["Row"];
       };
-      launch_project_with_active_cap: {
-        Args: {
-          project_id: string;
-          max_active: number;
+        launch_project_with_active_cap: {
+          Args: {
+            project_id: string;
+            max_active: number;
+          };
+          Returns: Database["public"]["Tables"]["projects"]["Row"];
         };
-        Returns: Database["public"]["Tables"]["projects"]["Row"];
-      };
-      get_github_connection_state: {
-        Args: Record<string, never>;
-        Returns: {
-          connected: boolean;
+        freeze_project_with_snapshot: {
+          Args: {
+            project_id: string;
+            snapshot_summary: string;
+            snapshot_label: string | null;
+            snapshot_left_out: string | null;
+            snapshot_future_note: string | null;
+          };
+          Returns: Database["public"]["Tables"]["projects"]["Row"];
+        };
+        finish_project_with_snapshot: {
+          Args: {
+            project_id: string;
+            snapshot_summary: string;
+            snapshot_label: string | null;
+            snapshot_left_out: string | null;
+            snapshot_future_note: string | null;
+          };
+          Returns: Database["public"]["Tables"]["projects"]["Row"];
+        };
+        get_github_connection_state: {
+          Args: Record<string, never>;
+          Returns: {
+            connected: boolean;
           github_login: string | null;
         }[];
       };

--- a/lib/usecases/project-snapshots.ts
+++ b/lib/usecases/project-snapshots.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { createClient } from "../supabase/server";
+import type { Database } from "../supabase/types";
+
+export type ProjectSnapshotRow =
+  Database["public"]["Tables"]["project_snapshots"]["Row"];
+
+export async function fetchProjectSnapshots(
+  projectId: string,
+): Promise<ProjectSnapshotRow[]> {
+  if (!projectId) {
+    throw new Error("Project id is required.");
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("project_snapshots")
+    .select("*")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load snapshots: ${error.message}`);
+  }
+
+  return data ?? [];
+}

--- a/supabase/migrations/20250125000000_project_snapshots.sql
+++ b/supabase/migrations/20250125000000_project_snapshots.sql
@@ -1,0 +1,13 @@
+create table if not exists public.project_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  kind text not null check (kind in ('freeze', 'finish')),
+  label text,
+  summary text not null check (char_length(trim(summary)) > 0),
+  left_out text,
+  future_note text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists project_snapshots_project_id_idx
+  on public.project_snapshots (project_id);

--- a/supabase/migrations/20250125000001_project_snapshot_actions.sql
+++ b/supabase/migrations/20250125000001_project_snapshot_actions.sql
@@ -1,0 +1,96 @@
+create or replace function public.freeze_project_with_snapshot(
+  project_id uuid,
+  snapshot_summary text,
+  snapshot_label text,
+  snapshot_left_out text,
+  snapshot_future_note text
+)
+returns public.projects
+language plpgsql
+as $$
+declare
+  updated_project public.projects;
+begin
+  if snapshot_summary is null or char_length(trim(snapshot_summary)) = 0 then
+    raise exception 'Snapshot summary required.';
+  end if;
+
+  update public.projects
+    set status = 'frozen'
+    where id = project_id
+      and status = 'active'
+    returning * into updated_project;
+
+  if not found then
+    raise exception 'Project status changed before update; please refresh and try again.';
+  end if;
+
+  insert into public.project_snapshots (
+    project_id,
+    kind,
+    label,
+    summary,
+    left_out,
+    future_note
+  )
+  values (
+    project_id,
+    'freeze',
+    snapshot_label,
+    snapshot_summary,
+    snapshot_left_out,
+    snapshot_future_note
+  );
+
+  return updated_project;
+end;
+$$;
+
+create or replace function public.finish_project_with_snapshot(
+  project_id uuid,
+  snapshot_summary text,
+  snapshot_label text,
+  snapshot_left_out text,
+  snapshot_future_note text
+)
+returns public.projects
+language plpgsql
+as $$
+declare
+  updated_project public.projects;
+begin
+  if snapshot_summary is null or char_length(trim(snapshot_summary)) = 0 then
+    raise exception 'Snapshot summary required.';
+  end if;
+
+  update public.projects
+    set status = 'archived',
+        finish_date = coalesce(finish_date, now())
+    where id = project_id
+      and status in ('active', 'frozen')
+    returning * into updated_project;
+
+  if not found then
+    raise exception 'Project status changed before update; please refresh and try again.';
+  end if;
+
+  insert into public.project_snapshots (
+    project_id,
+    kind,
+    label,
+    summary,
+    left_out,
+    future_note
+  )
+  values (
+    project_id,
+    'finish',
+    snapshot_label,
+    snapshot_summary,
+    snapshot_left_out,
+    snapshot_future_note
+  );
+
+  return updated_project;
+end;
+$$;


### PR DESCRIPTION
## What
- Add project snapshots table and RPCs for freeze/finish
- Require snapshot capture for Freeze/Finish actions
- Surface snapshots in project detail

## Why
- Preserve narrative memory at key lifecycle transitions

## How to test
- From /protected, click Freeze or Finish and submit a snapshot
- Confirm the project status updates and snapshot is created
- Open a project detail page and verify snapshots list appears

## Risks
- Snapshot modal flow adds extra steps to freeze/finish

## Screenshots
- N/A

Closes #PCE-401