### PR TITLE
PCE-402 Active cap override ritual

### DIFF
--- a/components/override-launch-button.tsx
+++ b/components/override-launch-button.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { SnapshotInput } from "@/components/snapshot-action-button";
+
+export type ActiveProjectOption = {
+  id: string;
+  name: string;
+  nextAction: string;
+};
+
+export type OverrideDecisionInput = {
+  reason: string;
+  tradeOff: string;
+};
+
+type OverrideLaunchButtonProps = {
+  projectId: string;
+  label: string;
+  activeProjects: ActiveProjectOption[];
+  onLaunch: (id: string) => Promise<void>;
+  onOverride: (
+    launchProjectId: string,
+    freezeProjectId: string,
+    snapshot: SnapshotInput,
+    decision: OverrideDecisionInput,
+  ) => Promise<void>;
+};
+
+function isActiveCapError(error: unknown) {
+  return error instanceof Error && error.message === "ACTIVE_CAP_REACHED";
+}
+
+export function OverrideLaunchButton({
+  projectId,
+  label,
+  activeProjects,
+  onLaunch,
+  onOverride,
+}: OverrideLaunchButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [isOpen, setIsOpen] = useState(false);
+  const [freezeProjectId, setFreezeProjectId] = useState("");
+  const [summary, setSummary] = useState("");
+  const [snapshotLabel, setSnapshotLabel] = useState("");
+  const [leftOut, setLeftOut] = useState("");
+  const [futureNote, setFutureNote] = useState("");
+  const [decisionReason, setDecisionReason] = useState("");
+  const [decisionTradeOff, setDecisionTradeOff] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const summaryId = `override-summary-${projectId}`;
+
+  const openDialog = () => {
+    setFreezeProjectId(activeProjects[0]?.id ?? "");
+    setIsOpen(true);
+  };
+
+  const closeDialog = () => {
+    setIsOpen(false);
+    setFreezeProjectId("");
+    setSummary("");
+    setSnapshotLabel("");
+    setLeftOut("");
+    setFutureNote("");
+    setDecisionReason("");
+    setDecisionTradeOff("");
+    setError(null);
+  };
+
+  const handleLaunch = () => {
+    startTransition(async () => {
+      try {
+        await onLaunch(projectId);
+        router.refresh();
+      } catch (error) {
+        if (isActiveCapError(error)) {
+          openDialog();
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to launch project. Please try again.";
+        toast.error(message);
+      }
+    });
+  };
+
+  const handleConfirm = () => {
+    if (!freezeProjectId) {
+      setError("Select a project to freeze.");
+      return;
+    }
+
+    if (!summary.trim()) {
+      setError("Snapshot summary is required.");
+      return;
+    }
+
+    if (!decisionReason.trim()) {
+      setError("Decision reason is required.");
+      return;
+    }
+
+    if (!decisionTradeOff.trim()) {
+      setError("Decision trade-off is required.");
+      return;
+    }
+
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        await onOverride(
+          projectId,
+          freezeProjectId,
+          {
+            summary: summary.trim(),
+            label: snapshotLabel.trim() || null,
+            leftOut: leftOut.trim() || null,
+            futureNote: futureNote.trim() || null,
+          },
+          {
+            reason: decisionReason.trim(),
+            tradeOff: decisionTradeOff.trim(),
+          },
+        );
+        closeDialog();
+        router.refresh();
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to override active cap. Please try again.";
+        toast.error(message);
+      }
+    });
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={isPending}
+        onClick={handleLaunch}
+      >
+        {label}
+      </Button>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4"
+          role="dialog"
+          aria-modal="true"
+          onClick={closeDialog}
+        >
+          <div
+            className="w-full max-w-2xl rounded-lg border border-border bg-background p-5 shadow-lg"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="text-lg font-semibold">Override active cap</div>
+            <p className="text-sm text-muted-foreground">
+              Freeze one active project and capture a decision before launching.
+            </p>
+
+            <div className="mt-4 grid gap-2">
+              <div className="text-sm font-medium">Freeze this project</div>
+              {activeProjects.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No active projects available to freeze.
+                </p>
+              ) : (
+                <div className="grid gap-2">
+                  {activeProjects.map((project) => (
+                    <label
+                      key={project.id}
+                      className="flex items-start gap-2 rounded border border-border px-3 py-2 text-sm"
+                    >
+                      <input
+                        type="radio"
+                        name={`freeze-project-${projectId}`}
+                        value={project.id}
+                        checked={freezeProjectId === project.id}
+                        onChange={() => setFreezeProjectId(project.id)}
+                      />
+                      <span>
+                        <span className="font-medium">{project.name}</span>
+                        <span className="block text-xs text-muted-foreground">
+                          Next action: {project.nextAction || "-"}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={summaryId}>Freeze snapshot summary</Label>
+              <textarea
+                id={summaryId}
+                name="summary"
+                value={summary}
+                onChange={(event) => setSummary(event.target.value)}
+                className="min-h-24 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-label`}>Label (optional)</Label>
+              <Input
+                id={`${summaryId}-label`}
+                name="label"
+                value={snapshotLabel}
+                onChange={(event) => setSnapshotLabel(event.target.value)}
+              />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-left-out`}>Left out (optional)</Label>
+              <textarea
+                id={`${summaryId}-left-out`}
+                name="leftOut"
+                value={leftOut}
+                onChange={(event) => setLeftOut(event.target.value)}
+                className="min-h-20 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-future-note`}>
+                Future note (optional)
+              </Label>
+              <textarea
+                id={`${summaryId}-future-note`}
+                name="futureNote"
+                value={futureNote}
+                onChange={(event) => setFutureNote(event.target.value)}
+                className="min-h-20 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-reason`}>Decision reason</Label>
+              <textarea
+                id={`${summaryId}-reason`}
+                name="reason"
+                value={decisionReason}
+                onChange={(event) => setDecisionReason(event.target.value)}
+                className="min-h-20 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label htmlFor={`${summaryId}-trade-off`}>
+                Decision trade-off
+              </Label>
+              <textarea
+                id={`${summaryId}-trade-off`}
+                name="tradeOff"
+                value={decisionTradeOff}
+                onChange={(event) => setDecisionTradeOff(event.target.value)}
+                className="min-h-20 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+
+            {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+
+            <div className="mt-5 flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={closeDialog}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleConfirm}
+                disabled={isPending || activeProjects.length === 0}
+              >
+                Freeze and launch
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -114,6 +114,33 @@ export type Database = {
           };
           Relationships: [];
         };
+        project_decisions: {
+          Row: {
+            id: string;
+            project_id: string;
+            decision_type: string;
+            reason: string;
+            trade_off: string;
+            created_at: string;
+          };
+          Insert: {
+            id?: string;
+            project_id: string;
+            decision_type: string;
+            reason: string;
+            trade_off: string;
+            created_at?: string;
+          };
+          Update: {
+            id?: string;
+            project_id?: string;
+            decision_type?: string;
+            reason?: string;
+            trade_off?: string;
+            created_at?: string;
+          };
+          Relationships: [];
+        };
         projects: {
           Row: {
             id: string;
@@ -193,6 +220,20 @@ export type Database = {
             snapshot_label: string | null;
             snapshot_left_out: string | null;
             snapshot_future_note: string | null;
+          };
+          Returns: Database["public"]["Tables"]["projects"]["Row"];
+        };
+        override_active_cap_with_freeze: {
+          Args: {
+            project_to_launch_id: string;
+            project_to_freeze_id: string;
+            snapshot_summary: string;
+            snapshot_label: string | null;
+            snapshot_left_out: string | null;
+            snapshot_future_note: string | null;
+            decision_reason: string;
+            decision_trade_off: string;
+            max_active: number;
           };
           Returns: Database["public"]["Tables"]["projects"]["Row"];
         };

--- a/lib/usecases/projects.ts
+++ b/lib/usecases/projects.ts
@@ -32,11 +32,21 @@ export type ProjectSnapshotInput = {
   futureNote?: string | null;
 };
 
+export type OverrideDecisionInput = {
+  reason: string;
+  tradeOff: string;
+};
+
 type SnapshotPayload = {
   summary: string;
   label: string | null;
   leftOut: string | null;
   futureNote: string | null;
+};
+
+type DecisionPayload = {
+  reason: string;
+  tradeOff: string;
 };
 
 function normalizeSnapshotValue(value: string | null | undefined): string | null {
@@ -58,6 +68,24 @@ function buildSnapshotPayload(input: ProjectSnapshotInput): SnapshotPayload {
     label: normalizeSnapshotValue(input.label),
     leftOut: normalizeSnapshotValue(input.leftOut),
     futureNote: normalizeSnapshotValue(input.futureNote),
+  };
+}
+
+function buildDecisionPayload(input: OverrideDecisionInput): DecisionPayload {
+  if (typeof input.reason !== "string" || input.reason.trim().length === 0) {
+    throw new Error("Decision reason is required.");
+  }
+
+  if (
+    typeof input.tradeOff !== "string" ||
+    input.tradeOff.trim().length === 0
+  ) {
+    throw new Error("Decision trade-off is required.");
+  }
+
+  return {
+    reason: input.reason.trim(),
+    tradeOff: input.tradeOff.trim(),
   };
 }
 
@@ -291,6 +319,9 @@ export async function applyLifecycleAction(
           .maybeSingle();
 
   if (error) {
+    if (action === "launch" && error.message === "ACTIVE_CAP_REACHED") {
+      throw new Error("ACTIVE_CAP_REACHED");
+    }
     throw new Error(`Failed to ${action} project: ${error.message}`);
   }
 
@@ -298,6 +329,49 @@ export async function applyLifecycleAction(
     throw new Error(
       "Project status changed before update; please refresh and try again.",
     );
+  }
+
+  return toProject(data);
+}
+
+export async function overrideActiveCap(
+  launchProjectId: string,
+  freezeProjectId: string,
+  snapshot: ProjectSnapshotInput,
+  decision: OverrideDecisionInput,
+): Promise<Project> {
+  if (!launchProjectId || !freezeProjectId) {
+    throw new Error("Project id is required.");
+  }
+
+  if (launchProjectId === freezeProjectId) {
+    throw new Error("Override requires two different projects.");
+  }
+
+  const snapshotPayload = buildSnapshotPayload(snapshot);
+  const decisionPayload = buildDecisionPayload(decision);
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .rpc("override_active_cap_with_freeze", {
+      project_to_launch_id: launchProjectId,
+      project_to_freeze_id: freezeProjectId,
+      snapshot_summary: snapshotPayload.summary,
+      snapshot_label: snapshotPayload.label,
+      snapshot_left_out: snapshotPayload.leftOut,
+      snapshot_future_note: snapshotPayload.futureNote,
+      decision_reason: decisionPayload.reason,
+      decision_trade_off: decisionPayload.tradeOff,
+      max_active: ACTIVE_PROJECT_LIMIT,
+    })
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to override active cap: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error("Override failed; no data returned.");
   }
 
   return toProject(data);

--- a/supabase/migrations/20250125000002_project_decisions.sql
+++ b/supabase/migrations/20250125000002_project_decisions.sql
@@ -1,0 +1,11 @@
+create table if not exists public.project_decisions (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  decision_type text not null check (decision_type in ('override')),
+  reason text not null check (char_length(trim(reason)) > 0),
+  trade_off text not null check (char_length(trim(trade_off)) > 0),
+  created_at timestamptz not null default now()
+);
+
+create index if not exists project_decisions_project_id_idx
+  on public.project_decisions (project_id);

--- a/supabase/migrations/20250125000003_active_cap_error_code.sql
+++ b/supabase/migrations/20250125000003_active_cap_error_code.sql
@@ -1,0 +1,95 @@
+create or replace function public.create_project_with_active_cap(
+  name text,
+  narrative_link text,
+  why_now text,
+  finish_definition text,
+  status text,
+  next_action text,
+  start_date timestamptz,
+  finish_date timestamptz,
+  max_active integer
+)
+returns public.projects
+language plpgsql
+as $$
+declare
+  active_count integer;
+  new_project public.projects;
+begin
+  if status = 'active' then
+    perform pg_advisory_xact_lock(hashtext('active_project_cap'));
+
+    select count(*) into active_count
+      from public.projects
+      where status = 'active';
+
+    if active_count >= max_active then
+      raise exception using
+        message = 'ACTIVE_CAP_REACHED',
+        detail = format('Active project limit reached (%). Freeze or finish a project before launching another.', max_active);
+    end if;
+  end if;
+
+  insert into public.projects (
+    name,
+    narrative_link,
+    why_now,
+    finish_definition,
+    status,
+    next_action,
+    start_date,
+    finish_date
+  )
+  values (
+    name,
+    narrative_link,
+    why_now,
+    finish_definition,
+    status,
+    next_action,
+    start_date,
+    finish_date
+  )
+  returning * into new_project;
+
+  return new_project;
+end;
+$$;
+
+create or replace function public.launch_project_with_active_cap(
+  project_id uuid,
+  max_active integer
+)
+returns public.projects
+language plpgsql
+as $$
+declare
+  active_count integer;
+  updated_project public.projects;
+begin
+  perform pg_advisory_xact_lock(hashtext('active_project_cap'));
+
+  select count(*) into active_count
+    from public.projects
+    where status = 'active';
+
+  if active_count >= max_active then
+    raise exception using
+      message = 'ACTIVE_CAP_REACHED',
+      detail = format('Active project limit reached (%). Freeze or finish a project before launching another.', max_active);
+  end if;
+
+  update public.projects
+    set status = 'active',
+        start_date = coalesce(start_date, now())
+    where id = project_id
+      and status = 'frozen'
+    returning * into updated_project;
+
+  if not found then
+    raise exception 'Project status changed before update; please refresh and try again.';
+  end if;
+
+  return updated_project;
+end;
+$$;

--- a/supabase/migrations/20250125000004_override_active_cap.sql
+++ b/supabase/migrations/20250125000004_override_active_cap.sql
@@ -1,0 +1,99 @@
+create or replace function public.override_active_cap_with_freeze(
+  project_to_launch_id uuid,
+  project_to_freeze_id uuid,
+  snapshot_summary text,
+  snapshot_label text,
+  snapshot_left_out text,
+  snapshot_future_note text,
+  decision_reason text,
+  decision_trade_off text,
+  max_active integer
+)
+returns public.projects
+language plpgsql
+as $$
+declare
+  active_count integer;
+  frozen_project public.projects;
+  launched_project public.projects;
+begin
+  if project_to_launch_id = project_to_freeze_id then
+    raise exception 'Override projects must be different.';
+  end if;
+
+  if snapshot_summary is null or char_length(trim(snapshot_summary)) = 0 then
+    raise exception 'Snapshot summary required.';
+  end if;
+
+  if decision_reason is null or char_length(trim(decision_reason)) = 0 then
+    raise exception 'Decision reason required.';
+  end if;
+
+  if decision_trade_off is null or char_length(trim(decision_trade_off)) = 0 then
+    raise exception 'Decision trade-off required.';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtext('active_project_cap'));
+
+  select count(*) into active_count
+    from public.projects
+    where status = 'active';
+
+  if active_count < max_active then
+    raise exception 'Override not required.';
+  end if;
+
+  update public.projects
+    set status = 'frozen'
+    where id = project_to_freeze_id
+      and status = 'active'
+    returning * into frozen_project;
+
+  if not found then
+    raise exception 'Project status changed before update; please refresh and try again.';
+  end if;
+
+  insert into public.project_snapshots (
+    project_id,
+    kind,
+    label,
+    summary,
+    left_out,
+    future_note
+  )
+  values (
+    project_to_freeze_id,
+    'freeze',
+    snapshot_label,
+    snapshot_summary,
+    snapshot_left_out,
+    snapshot_future_note
+  );
+
+  insert into public.project_decisions (
+    project_id,
+    decision_type,
+    reason,
+    trade_off
+  )
+  values (
+    project_to_launch_id,
+    'override',
+    decision_reason,
+    decision_trade_off
+  );
+
+  update public.projects
+    set status = 'active',
+        start_date = coalesce(start_date, now())
+    where id = project_to_launch_id
+      and status = 'frozen'
+    returning * into launched_project;
+
+  if not found then
+    raise exception 'Project status changed before update; please refresh and try again.';
+  end if;
+
+  return launched_project;
+end;
+$$;


### PR DESCRIPTION
## What
- Add override ritual modal for Launch when active cap is reached
- Store override decision + freeze snapshot in a single RPC
- Return ACTIVE_CAP_REACHED as a stable backend error

## Why
- Convert the active cap from a hard error into a deliberate decision with explicit cost

## How to test
- Ensure 3 projects are Active, then attempt to Launch a frozen project
- Verify the override modal opens and requires snapshot + decision
- Confirm one active project freezes and the target project launches

## Risks
- Override flow adds a multi-step modal that can block launch

## Screenshots
- N/A

Closes #PCE-402