### PR TITLE
PCE-401 Define persistence ports

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,67 @@
+# Issues
+
+## Epic 5 - Persistence Ports + Supabase Adapter (V1.2)
+
+Goal: Decouple use-cases from Supabase so persistence can be swapped later.
+
+### PCE-401 Define persistence ports (interfaces)
+
+Goal: Add explicit persistence ports that use-cases can depend on.
+
+Scope:
+- Define TypeScript interfaces for each use-case area (projects, project snapshots,
+  GitHub connections, repo drafts).
+- Decide and document port module location (ex: `lib/usecases/ports/`).
+- Ensure ports accept user context/userId as input (auth stays outside persistence).
+
+Out of scope:
+- Supabase implementation details.
+
+Acceptance criteria:
+- Ports are defined with no Supabase imports or types.
+- Ports describe all methods currently used by use-cases.
+- Ports require user context/userId in method signatures where needed.
+
+### PCE-402 Implement Supabase adapters behind the ports
+
+Goal: Provide Supabase-backed implementations for the new ports.
+
+Scope:
+- Implement adapters that satisfy the ports using existing Supabase clients.
+- Keep auth in the calling layer (adapters do not call `auth.getClaims()`).
+
+Out of scope:
+- Refactor use-cases to consume the ports (handled in PCE-403).
+
+Acceptance criteria:
+- Each port has a working Supabase adapter.
+- Adapters compile without changing use-cases yet.
+
+### PCE-403 Refactor use-cases to depend only on ports
+
+Goal: Remove direct Supabase usage from use-cases.
+
+Scope:
+- Update `lib/usecases/*.ts` to accept ports via dependency injection (function params
+  or a factory module).
+- Move auth resolution to the calling layer and pass userId/context into use-cases.
+
+Out of scope:
+- UI changes not required for wiring the new ports.
+
+Acceptance criteria:
+- `lib/usecases/*` has no Supabase imports.
+- All use-cases compile and run using port interfaces.
+- Supabase is only referenced in adapter/infrastructure modules.
+
+### PCE-404 Align tests and smoke checks after refactor
+
+Goal: Ensure behavior is unchanged after the decoupling.
+
+Scope:
+- Update any existing tests or add minimal coverage for ports/adapters if none exist.
+- Re-run smoke test flow and update notes if needed.
+
+Acceptance criteria:
+- App smoke flow still works end-to-end.
+- Any test or smoke documentation is updated to reflect the new wiring.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,3 +60,14 @@ Goal: Add lightweight insights and a review flow, plus mobile responsiveness pol
 - [x] PCE-302 Review mode (weekly checklist + stale next actions)
 - [x] PCE-303 Review history (last reviewed timestamp per project)
 - [x] PCE-304 Mobile responsiveness pass (dashboard, drafts, forms)
+
+## Epic 5 - Persistence Ports + Supabase Adapter (V1.2)
+
+Goal: Decouple use-cases from Supabase so persistence can be swapped later.
+
+### Tickets
+
+- [ ] PCE-401 Define persistence ports (interfaces) for current use-cases.
+- [ ] PCE-402 Implement Supabase adapters behind the ports.
+- [ ] PCE-403 Refactor use-cases to depend only on ports.
+- [ ] PCE-404 Align tests and smoke checks after the refactor.

--- a/docs/adr/0004-ports-and-adapters.md
+++ b/docs/adr/0004-ports-and-adapters.md
@@ -15,6 +15,7 @@ Supabase adapters behind those ports. Use-cases will depend only on the ports,
 not on Supabase clients or types.
 Auth/session resolution stays outside persistence (use-cases receive user
 context/userId; adapters do not call Supabase auth).
+Ports live in `lib/usecases/ports/`.
 
 ## Alternatives considered
 

--- a/docs/adr/0004-ports-and-adapters.md
+++ b/docs/adr/0004-ports-and-adapters.md
@@ -1,0 +1,29 @@
+# ADR 0004: Introduce persistence ports and adapters
+
+## Context
+
+The current codebase couples use-cases directly to Supabase clients and types.
+This makes the persistence layer hard to replace and increases the cost of
+moving to another Postgres provider (ex: Railway) later. We want to keep
+Supabase for now while designing the app so persistence can be swapped without
+rewriting core use-cases.
+
+## Decision
+
+Introduce explicit persistence ports (interfaces) for use-cases and implement
+Supabase adapters behind those ports. Use-cases will depend only on the ports,
+not on Supabase clients or types.
+Auth/session resolution stays outside persistence (use-cases receive user
+context/userId; adapters do not call Supabase auth).
+
+## Alternatives considered
+
+- Keep direct Supabase usage in use-cases and accept provider lock-in.
+- Rewrite immediately to a new provider (higher risk, more work now).
+
+## Consequences
+
+- Adds a thin abstraction layer (ports + adapters) and some up-front refactor.
+- Reduces lock-in and lowers the cost of migrating to another Postgres
+  provider later.
+- Requires a clear boundary between domain/use-cases and infrastructure.

--- a/lib/usecases/ports/github-connections.ts
+++ b/lib/usecases/ports/github-connections.ts
@@ -1,0 +1,29 @@
+import type { UserContext } from "./user-context";
+
+export type GitHubConnectionState = {
+  connected: boolean;
+  githubLogin?: string;
+};
+
+export type GitHubConnection = {
+  id: string;
+  userId: string;
+  githubUserId: number;
+  githubLogin: string;
+  accessToken: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type UpsertGitHubConnectionInput = {
+  userId: string;
+  githubUserId: number;
+  githubLogin: string;
+  accessToken: string;
+};
+
+export interface GitHubConnectionsPort {
+  getConnectionState(context: UserContext): Promise<GitHubConnectionState>;
+  getAccessToken(context: UserContext): Promise<string | null>;
+  upsertConnection(input: UpsertGitHubConnectionInput): Promise<GitHubConnection>;
+}

--- a/lib/usecases/ports/index.ts
+++ b/lib/usecases/ports/index.ts
@@ -1,0 +1,24 @@
+export type { UserContext } from "./user-context";
+export type {
+  ProjectSnapshotInput,
+  OverrideDecisionInput,
+  OverrideActiveCapInput,
+  ProjectsPort,
+} from "./projects";
+export type {
+  ProjectSnapshot,
+  ProjectSnapshotKind,
+  ProjectSnapshotsPort,
+} from "./project-snapshots";
+export type {
+  GitHubConnection,
+  GitHubConnectionState,
+  UpsertGitHubConnectionInput,
+  GitHubConnectionsPort,
+} from "./github-connections";
+export type {
+  RepoDraft,
+  RepoDraftImport,
+  RepoDraftConversionInput,
+  RepoDraftsPort,
+} from "./repo-drafts";

--- a/lib/usecases/ports/project-snapshots.ts
+++ b/lib/usecases/ports/project-snapshots.ts
@@ -1,0 +1,16 @@
+export type ProjectSnapshotKind = "freeze" | "finish";
+
+export type ProjectSnapshot = {
+  id: string;
+  projectId: string;
+  kind: ProjectSnapshotKind;
+  label: string | null;
+  summary: string;
+  leftOut: string | null;
+  futureNote: string | null;
+  createdAt: string;
+};
+
+export interface ProjectSnapshotsPort {
+  fetchProjectSnapshots(projectId: string): Promise<ProjectSnapshot[]>;
+}

--- a/lib/usecases/ports/projects.ts
+++ b/lib/usecases/ports/projects.ts
@@ -1,0 +1,54 @@
+import type {
+  NewProjectInput,
+  Project,
+  ProjectStatus,
+  UpdateProjectInput,
+} from "@/lib/domain/project";
+
+export type ProjectSnapshotInput = {
+  summary: string;
+  label?: string | null;
+  leftOut?: string | null;
+  futureNote?: string | null;
+};
+
+export type OverrideDecisionInput = {
+  reason: string;
+  tradeOff: string;
+};
+
+export type OverrideActiveCapInput = {
+  launchProjectId: string;
+  freezeProjectId: string;
+  snapshot: ProjectSnapshotInput;
+  decision: OverrideDecisionInput;
+  maxActive: number;
+};
+
+export interface ProjectsPort {
+  createProject(
+    input: NewProjectInput,
+    options: { enforceActiveCap: boolean; maxActive: number },
+  ): Promise<Project>;
+  updateProject(id: string, updates: UpdateProjectInput): Promise<Project>;
+  fetchProjectById(id: string): Promise<Project | null>;
+  freezeProjectWithSnapshot(
+    id: string,
+    snapshot: ProjectSnapshotInput,
+  ): Promise<Project>;
+  finishProjectWithSnapshot(
+    id: string,
+    snapshot: ProjectSnapshotInput,
+  ): Promise<Project>;
+  launchProjectWithActiveCap(id: string, maxActive: number): Promise<Project>;
+  archiveProject(
+    id: string,
+    expectedStatus: ProjectStatus,
+  ): Promise<Project | null>;
+  overrideActiveCapWithFreeze(input: OverrideActiveCapInput): Promise<Project>;
+  restartArchivedProject(
+    projectId: string,
+    nextAction: string,
+  ): Promise<Project>;
+  deleteArchivedProject(id: string): Promise<boolean>;
+}

--- a/lib/usecases/ports/repo-drafts.ts
+++ b/lib/usecases/ports/repo-drafts.ts
@@ -1,0 +1,51 @@
+import type { UserContext } from "./user-context";
+
+export type RepoDraft = {
+  id: string;
+  userId: string;
+  githubRepoId: number;
+  fullName: string;
+  htmlUrl: string;
+  description: string | null;
+  visibility: string;
+  defaultBranch: string;
+  pushedAt: string | null;
+  topics: string[] | null;
+  importedAt: string;
+  convertedProjectId: string | null;
+  convertedAt: string | null;
+};
+
+export type RepoDraftImport = {
+  githubRepoId: number;
+  fullName: string;
+  htmlUrl: string;
+  description: string | null;
+  visibility: string;
+  defaultBranch: string;
+  pushedAt: string | null;
+  topics?: string[] | null;
+};
+
+export type RepoDraftConversionInput = {
+  name: string;
+  nextAction: string;
+  finishDefinition?: string | null;
+};
+
+export interface RepoDraftsPort {
+  upsertRepoDrafts(
+    context: UserContext,
+    drafts: RepoDraftImport[],
+  ): Promise<number>;
+  fetchRepoDrafts(context: UserContext): Promise<RepoDraft[]>;
+  fetchRepoDraftById(
+    context: UserContext,
+    id: string,
+  ): Promise<RepoDraft | null>;
+  convertRepoDraft(
+    context: UserContext,
+    id: string,
+    input: RepoDraftConversionInput,
+  ): Promise<string>;
+}

--- a/lib/usecases/ports/user-context.ts
+++ b/lib/usecases/ports/user-context.ts
@@ -1,0 +1,3 @@
+export type UserContext = {
+  userId: string;
+};


### PR DESCRIPTION
## What/Why
- Define persistence ports (interfaces) for projects, project snapshots, GitHub connections, and repo drafts to decouple use-cases from Supabase.
- Document port location and clarify that auth stays outside persistence.

## How to test
- No runtime changes; type-only additions.

## Risks
- Minimal; no behavior changes.

Closes #32