### PR TITLE
PCE-402 Implement Supabase adapters

### DIFF
--- a/lib/clients/supabase/github-connections-adapter.ts
+++ b/lib/clients/supabase/github-connections-adapter.ts
@@ -1,0 +1,90 @@
+import "server-only";
+
+import type { Database } from "@/lib/supabase/types";
+import { createServiceClient } from "@/lib/supabase/server";
+import type {
+  GitHubConnection,
+  GitHubConnectionState,
+  GitHubConnectionsPort,
+  UpsertGitHubConnectionInput,
+  UserContext,
+} from "@/lib/usecases/ports";
+
+type GitHubConnectionRow =
+  Database["public"]["Tables"]["github_connections"]["Row"];
+
+function toGitHubConnection(row: GitHubConnectionRow): GitHubConnection {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    githubUserId: row.github_user_id,
+    githubLogin: row.github_login,
+    accessToken: row.access_token,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function fetchConnectionRow(context: UserContext) {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("github_connections")
+    .select("*")
+    .eq("user_id", context.userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load GitHub connection: ${error.message}`);
+  }
+
+  return data;
+}
+
+export const supabaseGitHubConnectionsAdapter: GitHubConnectionsPort = {
+  async getConnectionState(context: UserContext): Promise<GitHubConnectionState> {
+    if (!context.userId) {
+      return { connected: false };
+    }
+
+    const connection = await fetchConnectionRow(context);
+
+    return connection
+      ? { connected: true, githubLogin: connection.github_login ?? undefined }
+      : { connected: false };
+  },
+
+  async getAccessToken(context: UserContext) {
+    if (!context.userId) {
+      return null;
+    }
+
+    const connection = await fetchConnectionRow(context);
+    return connection?.access_token ?? null;
+  },
+
+  async upsertConnection(input: UpsertGitHubConnectionInput) {
+    const supabase = createServiceClient();
+    const now = new Date().toISOString();
+
+    const { data, error } = await supabase
+      .from("github_connections")
+      .upsert(
+        {
+          user_id: input.userId,
+          github_user_id: input.githubUserId,
+          github_login: input.githubLogin,
+          access_token: input.accessToken,
+          updated_at: now,
+        },
+        { onConflict: "user_id" },
+      )
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to store GitHub connection: ${error.message}`);
+    }
+
+    return toGitHubConnection(data);
+  },
+};

--- a/lib/clients/supabase/index.ts
+++ b/lib/clients/supabase/index.ts
@@ -1,0 +1,4 @@
+export { supabaseProjectsAdapter } from "./projects-adapter";
+export { supabaseProjectSnapshotsAdapter } from "./project-snapshots-adapter";
+export { supabaseGitHubConnectionsAdapter } from "./github-connections-adapter";
+export { supabaseRepoDraftsAdapter } from "./repo-drafts-adapter";

--- a/lib/clients/supabase/project-snapshots-adapter.ts
+++ b/lib/clients/supabase/project-snapshots-adapter.ts
@@ -1,0 +1,40 @@
+import "server-only";
+
+import type { Database } from "@/lib/supabase/types";
+import { createServiceClient } from "@/lib/supabase/server";
+import type {
+  ProjectSnapshot,
+  ProjectSnapshotsPort,
+} from "@/lib/usecases/ports";
+
+type ProjectSnapshotRow = Database["public"]["Tables"]["project_snapshots"]["Row"];
+
+function toProjectSnapshot(row: ProjectSnapshotRow): ProjectSnapshot {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    kind: row.kind as ProjectSnapshot["kind"],
+    label: row.label,
+    summary: row.summary,
+    leftOut: row.left_out,
+    futureNote: row.future_note,
+    createdAt: row.created_at,
+  };
+}
+
+export const supabaseProjectSnapshotsAdapter: ProjectSnapshotsPort = {
+  async fetchProjectSnapshots(projectId) {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("project_snapshots")
+      .select("*")
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      throw new Error(`Failed to load snapshots: ${error.message}`);
+    }
+
+    return (data ?? []).map(toProjectSnapshot);
+  },
+};

--- a/lib/clients/supabase/projects-adapter.ts
+++ b/lib/clients/supabase/projects-adapter.ts
@@ -1,0 +1,362 @@
+import "server-only";
+
+import type {
+  NewProjectInput,
+  Project,
+  ProjectStatus,
+  UpdateProjectInput,
+} from "@/lib/domain/project";
+import type { Database } from "@/lib/supabase/types";
+import { createServiceClient } from "@/lib/supabase/server";
+import type {
+  OverrideActiveCapInput,
+  ProjectSnapshotInput,
+  ProjectsPort,
+} from "@/lib/usecases/ports";
+
+type ProjectRow = Database["public"]["Tables"]["projects"]["Row"];
+type ProjectInsert = Database["public"]["Tables"]["projects"]["Insert"];
+type ProjectUpdate = Database["public"]["Tables"]["projects"]["Update"];
+
+const DEFAULT_STATUS: ProjectStatus = "active";
+
+type SnapshotPayload = {
+  summary: string;
+  label: string | null;
+  leftOut: string | null;
+  futureNote: string | null;
+};
+
+function toProject(row: ProjectRow): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    narrativeLink: row.narrative_link,
+    whyNow: row.why_now,
+    finishDefinition: row.finish_definition,
+    status: row.status,
+    nextAction: row.next_action,
+    startDate: row.start_date,
+    finishDate: row.finish_date,
+    lastReviewedAt: row.last_reviewed_at,
+  };
+}
+
+function normalizeSnapshotValue(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function buildSnapshotPayload(input: ProjectSnapshotInput): SnapshotPayload {
+  return {
+    summary: input.summary.trim(),
+    label: normalizeSnapshotValue(input.label),
+    leftOut: normalizeSnapshotValue(input.leftOut),
+    futureNote: normalizeSnapshotValue(input.futureNote),
+  };
+}
+
+function buildProjectInsert(input: NewProjectInput): ProjectInsert {
+  const status = input.status ?? DEFAULT_STATUS;
+
+  return {
+    name: input.name.trim(),
+    narrative_link: input.narrativeLink ?? null,
+    why_now: input.whyNow ?? null,
+    finish_definition: input.finishDefinition ?? null,
+    status,
+    next_action: input.nextAction.trim(),
+    start_date: status === "active" ? new Date().toISOString() : null,
+    finish_date: null,
+    last_reviewed_at: null,
+  };
+}
+
+function buildProjectUpdate(input: UpdateProjectInput): ProjectUpdate {
+  const update: ProjectUpdate = {};
+
+  if (input.name !== undefined) {
+    update.name = input.name.trim();
+  }
+
+  if (input.narrativeLink !== undefined) {
+    update.narrative_link = input.narrativeLink ?? null;
+  }
+
+  if (input.whyNow !== undefined) {
+    update.why_now = input.whyNow ?? null;
+  }
+
+  if (input.finishDefinition !== undefined) {
+    update.finish_definition = input.finishDefinition ?? null;
+  }
+
+  if (input.status !== undefined) {
+    update.status = input.status;
+  }
+
+  if (input.nextAction !== undefined) {
+    update.next_action = input.nextAction.trim();
+  }
+
+  if (input.lastReviewedAt !== undefined) {
+    update.last_reviewed_at = input.lastReviewedAt ?? null;
+  }
+
+  return update;
+}
+
+export const supabaseProjectsAdapter: ProjectsPort = {
+  async createProject(input, options) {
+    const supabase = createServiceClient();
+    const insert = buildProjectInsert(input);
+    const enforceCap = options.enforceActiveCap && insert.status === "active";
+
+    const { data, error } = enforceCap
+      ? await supabase
+          .rpc("create_project_with_active_cap", {
+            finish_definition: insert.finish_definition ?? null,
+            finish_date: insert.finish_date ?? null,
+            max_active: options.maxActive,
+            name: insert.name,
+            narrative_link: insert.narrative_link ?? null,
+            next_action: insert.next_action,
+            start_date: insert.start_date ?? null,
+            status: insert.status,
+            why_now: insert.why_now ?? null,
+          })
+          .single()
+      : await supabase.from("projects").insert(insert).select("*").single();
+
+    if (error) {
+      throw new Error(`Failed to create project: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error("Project creation failed; no data returned.");
+    }
+
+    return toProject(data);
+  },
+
+  async updateProject(id, updates) {
+    const supabase = createServiceClient();
+    const update = buildProjectUpdate(updates);
+
+    const { data, error } = await supabase
+      .from("projects")
+      .update(update)
+      .eq("id", id)
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to update project: ${error.message}`);
+    }
+
+    return toProject(data);
+  },
+
+  async fetchProjectById(id) {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("projects")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to fetch project: ${error.message}`);
+    }
+
+    return data ? toProject(data) : null;
+  },
+
+  async freezeProjectWithSnapshot(id, snapshot) {
+    const supabase = createServiceClient();
+    const payload = buildSnapshotPayload(snapshot);
+    const { data, error } = await supabase
+      .rpc("freeze_project_with_snapshot", {
+        project_id: id,
+        snapshot_summary: payload.summary,
+        snapshot_label: payload.label,
+        snapshot_left_out: payload.leftOut,
+        snapshot_future_note: payload.futureNote,
+      })
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to freeze project: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error(
+        "Project status changed before update; please refresh and try again.",
+      );
+    }
+
+    return toProject(data);
+  },
+
+  async finishProjectWithSnapshot(id, snapshot) {
+    const supabase = createServiceClient();
+    const payload = buildSnapshotPayload(snapshot);
+    const { data, error } = await supabase
+      .rpc("finish_project_with_snapshot", {
+        project_id: id,
+        snapshot_summary: payload.summary,
+        snapshot_label: payload.label,
+        snapshot_left_out: payload.leftOut,
+        snapshot_future_note: payload.futureNote,
+      })
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to finish project: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error(
+        "Project status changed before update; please refresh and try again.",
+      );
+    }
+
+    return toProject(data);
+  },
+
+  async launchProjectWithActiveCap(id, maxActive) {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .rpc("launch_project_with_active_cap", {
+        max_active: maxActive,
+        project_id: id,
+      })
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to launch project: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error(
+        "Project status changed before update; please refresh and try again.",
+      );
+    }
+
+    return toProject(data);
+  },
+
+  async archiveProject(id, expectedStatus) {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("projects")
+      .update({ status: "archived" })
+      .eq("id", id)
+      .eq("status", expectedStatus)
+      .select("*")
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to archive project: ${error.message}`);
+    }
+
+    return data ? toProject(data) : null;
+  },
+
+  async overrideActiveCapWithFreeze(input: OverrideActiveCapInput) {
+    const supabase = createServiceClient();
+    const payload = buildSnapshotPayload(input.snapshot);
+    const { data, error } = await supabase
+      .rpc("override_active_cap_with_freeze", {
+        project_to_launch_id: input.launchProjectId,
+        project_to_freeze_id: input.freezeProjectId,
+        snapshot_summary: payload.summary,
+        snapshot_label: payload.label,
+        snapshot_left_out: payload.leftOut,
+        snapshot_future_note: payload.futureNote,
+        decision_reason: input.decision.reason.trim(),
+        decision_trade_off: input.decision.tradeOff.trim(),
+        max_active: input.maxActive,
+      })
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to override active cap: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error("Override failed; no data returned.");
+    }
+
+    return toProject(data);
+  },
+
+  async restartArchivedProject(projectId, nextAction) {
+    const supabase = createServiceClient();
+    const { data: project, error: projectError } = await supabase
+      .from("projects")
+      .select("*")
+      .eq("id", projectId)
+      .maybeSingle();
+
+    if (projectError) {
+      throw new Error(`Failed to load project: ${projectError.message}`);
+    }
+
+    if (!project) {
+      throw new Error("Project not found.");
+    }
+
+    if (project.status !== "archived") {
+      throw new Error("Only archived projects can be restarted.");
+    }
+
+    const insert: ProjectInsert = {
+      name: project.name,
+      narrative_link: project.narrative_link,
+      why_now: project.why_now,
+      finish_definition: project.finish_definition,
+      status: "frozen",
+      next_action: nextAction.trim(),
+      start_date: null,
+      finish_date: null,
+    };
+
+    const { data, error } = await supabase
+      .from("projects")
+      .insert(insert)
+      .select("*")
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to restart project: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error("Project restart failed; no data returned.");
+    }
+
+    return toProject(data);
+  },
+
+  async deleteArchivedProject(id) {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("projects")
+      .delete()
+      .eq("id", id)
+      .eq("status", "archived")
+      .select("id")
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to delete project: ${error.message}`);
+    }
+
+    return !!data;
+  },
+};

--- a/lib/clients/supabase/repo-drafts-adapter.ts
+++ b/lib/clients/supabase/repo-drafts-adapter.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import type { Database } from "@/lib/supabase/types";
-import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/server";
 import type {
   RepoDraft,
   RepoDraftConversionInput,
@@ -114,10 +114,11 @@ export const supabaseRepoDraftsAdapter: RepoDraftsPort = {
       throw new Error("Missing user id.");
     }
 
-    const supabase = await createClient();
+    const supabase = createServiceClient();
     const { data: projectResult, error: convertError } = await supabase
-      .rpc("convert_repo_draft_to_project", {
+      .rpc("convert_repo_draft_to_project_service", {
         draft_id: id,
+        user_id: context.userId,
         project_name: input.name.trim(),
         next_action: input.nextAction.trim(),
         finish_definition: input.finishDefinition ?? null,

--- a/lib/clients/supabase/repo-drafts-adapter.ts
+++ b/lib/clients/supabase/repo-drafts-adapter.ts
@@ -1,0 +1,137 @@
+import "server-only";
+
+import type { Database } from "@/lib/supabase/types";
+import { createClient, createServiceClient } from "@/lib/supabase/server";
+import type {
+  RepoDraft,
+  RepoDraftConversionInput,
+  RepoDraftImport,
+  RepoDraftsPort,
+  UserContext,
+} from "@/lib/usecases/ports";
+
+type RepoDraftRow = Database["public"]["Tables"]["repo_drafts"]["Row"];
+
+function toRepoDraft(row: RepoDraftRow): RepoDraft {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    githubRepoId: row.github_repo_id,
+    fullName: row.full_name,
+    htmlUrl: row.html_url,
+    description: row.description,
+    visibility: row.visibility,
+    defaultBranch: row.default_branch,
+    pushedAt: row.pushed_at,
+    topics: row.topics,
+    importedAt: row.imported_at,
+    convertedProjectId: row.converted_project_id,
+    convertedAt: row.converted_at,
+  };
+}
+
+export const supabaseRepoDraftsAdapter: RepoDraftsPort = {
+  async upsertRepoDrafts(context: UserContext, drafts: RepoDraftImport[]) {
+    if (drafts.length === 0) {
+      return 0;
+    }
+
+    if (!context.userId) {
+      throw new Error("Missing user id.");
+    }
+
+    const supabase = createServiceClient();
+    const now = new Date().toISOString();
+    const payload = drafts.map((draft) => ({
+      user_id: context.userId,
+      github_repo_id: draft.githubRepoId,
+      full_name: draft.fullName,
+      html_url: draft.htmlUrl,
+      description: draft.description,
+      visibility: draft.visibility,
+      default_branch: draft.defaultBranch,
+      pushed_at: draft.pushedAt,
+      topics: draft.topics ?? null,
+      imported_at: now,
+    }));
+
+    const { error } = await supabase
+      .from("repo_drafts")
+      .upsert(payload, { onConflict: "user_id,github_repo_id" });
+
+    if (error) {
+      throw new Error(`Failed to import drafts: ${error.message}`);
+    }
+
+    return payload.length;
+  },
+
+  async fetchRepoDrafts(context: UserContext) {
+    if (!context.userId) {
+      throw new Error("Missing user id.");
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("repo_drafts")
+      .select("*")
+      .eq("user_id", context.userId)
+      .order("imported_at", { ascending: false });
+
+    if (error) {
+      throw new Error(`Failed to load drafts: ${error.message}`);
+    }
+
+    return (data ?? []).map(toRepoDraft);
+  },
+
+  async fetchRepoDraftById(context: UserContext, id: string) {
+    if (!context.userId) {
+      throw new Error("Missing user id.");
+    }
+
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("repo_drafts")
+      .select("*")
+      .eq("user_id", context.userId)
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to load draft: ${error.message}`);
+    }
+
+    return data ? toRepoDraft(data) : null;
+  },
+
+  async convertRepoDraft(
+    context: UserContext,
+    id: string,
+    input: RepoDraftConversionInput,
+  ) {
+    if (!context.userId) {
+      throw new Error("Missing user id.");
+    }
+
+    const supabase = await createClient();
+    const { data: projectResult, error: convertError } = await supabase
+      .rpc("convert_repo_draft_to_project", {
+        draft_id: id,
+        project_name: input.name.trim(),
+        next_action: input.nextAction.trim(),
+        finish_definition: input.finishDefinition ?? null,
+      })
+      .single();
+
+    if (convertError) {
+      throw new Error(`Failed to convert draft: ${convertError.message}`);
+    }
+
+    if (!projectResult?.project_id) {
+      throw new Error("Draft conversion failed.");
+    }
+
+    return projectResult.project_id;
+  },
+};

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -258,6 +258,18 @@ export type Database = {
           project_id: string;
         }[];
       };
+      convert_repo_draft_to_project_service: {
+        Args: {
+          draft_id: string;
+          user_id: string;
+          project_name: string;
+          next_action: string;
+          finish_definition: string | null;
+        };
+        Returns: {
+          project_id: string;
+        }[];
+      };
     };
     Enums: {
       [_ in never]: never;

--- a/supabase/migrations/20250127000000_convert_repo_draft_service.sql
+++ b/supabase/migrations/20250127000000_convert_repo_draft_service.sql
@@ -1,0 +1,69 @@
+create or replace function public.convert_repo_draft_to_project_service(
+  draft_id uuid,
+  user_id uuid,
+  project_name text,
+  next_action text,
+  finish_definition text
+)
+returns table (project_id uuid)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  draft_record public.repo_drafts;
+  trimmed_name text := btrim(project_name);
+  trimmed_next_action text := btrim(next_action);
+  new_project_id uuid;
+begin
+  if trimmed_name is null or trimmed_name = '' then
+    raise exception 'Project name is required.';
+  end if;
+
+  if trimmed_next_action is null or trimmed_next_action = '' then
+    raise exception 'Next action is required.';
+  end if;
+
+  if char_length(trimmed_next_action) > 140 then
+    raise exception 'Next action must be at most 140 characters.';
+  end if;
+
+  select * into draft_record
+    from public.repo_drafts
+    where id = draft_id
+      and user_id = convert_repo_draft_to_project_service.user_id
+      and converted_project_id is null
+    for update;
+
+  if not found then
+    raise exception 'Draft not found or already converted.';
+  end if;
+
+  insert into public.projects (
+    name,
+    narrative_link,
+    finish_definition,
+    status,
+    next_action,
+    start_date,
+    finish_date
+  )
+  values (
+    trimmed_name,
+    draft_record.html_url,
+    finish_definition,
+    'frozen',
+    trimmed_next_action,
+    null,
+    null
+  )
+  returning id into new_project_id;
+
+  update public.repo_drafts
+    set converted_project_id = new_project_id,
+        converted_at = now()
+    where id = draft_id;
+
+  return query select new_project_id as project_id;
+end;
+$$;

--- a/supabase/migrations/20250127000000_convert_repo_draft_service.sql
+++ b/supabase/migrations/20250127000000_convert_repo_draft_service.sql
@@ -67,3 +67,19 @@ begin
   return query select new_project_id as project_id;
 end;
 $$;
+
+revoke execute on function public.convert_repo_draft_to_project_service(
+  uuid,
+  uuid,
+  text,
+  text,
+  text
+) from public;
+
+grant execute on function public.convert_repo_draft_to_project_service(
+  uuid,
+  uuid,
+  text,
+  text,
+  text
+) to service_role;


### PR DESCRIPTION
## What/Why
- Add Supabase adapter implementations for the new persistence ports (projects, snapshots, GitHub connections, repo drafts).
- Keep auth resolution outside persistence by relying on user context or authenticated RPCs where needed.

## How to test
- No runtime wiring yet; these adapters are not used by the app.

## Risks
- Minimal; new modules only.

Closes #33