### PR TITLE
PCE-403 Refactor use-cases to use ports

### DIFF
--- a/app/auth/github/callback/route.ts
+++ b/app/auth/github/callback/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { NextResponse, type NextRequest } from "next/server";
 
+import { supabaseGitHubConnectionsAdapter } from "@/lib/clients/supabase";
 import { createClient } from "@/lib/supabase/server";
 import { upsertGitHubConnection } from "@/lib/usecases/github";
 
@@ -106,7 +107,7 @@ export async function GET(request: NextRequest) {
 
   const githubUser = await fetchGitHubUser(tokenResponse.access_token);
 
-  await upsertGitHubConnection({
+  await upsertGitHubConnection(supabaseGitHubConnectionsAdapter, {
     userId,
     githubUserId: githubUser.id,
     githubLogin: githubUser.login,

--- a/app/protected/github/drafts/page.tsx
+++ b/app/protected/github/drafts/page.tsx
@@ -3,7 +3,10 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
-import { createClient } from "@/lib/supabase/server";
+import {
+  getUserContext,
+  supabaseRepoDraftsAdapter,
+} from "@/lib/clients/supabase";
 import { fetchRepoDrafts } from "@/lib/usecases/github-drafts";
 
 function formatDate(value: string | null) {
@@ -15,14 +18,13 @@ function formatDate(value: string | null) {
 }
 
 async function DraftList() {
-  const supabase = await createClient();
-  const { data } = await supabase.auth.getClaims();
+  const userContext = await getUserContext();
 
-  if (!data?.claims) {
+  if (!userContext) {
     redirect("/auth/login");
   }
 
-  const drafts = await fetchRepoDrafts();
+  const drafts = await fetchRepoDrafts(supabaseRepoDraftsAdapter, userContext);
 
   if (drafts.length === 0) {
     return (
@@ -44,21 +46,21 @@ async function DraftList() {
               href={`/protected/github/drafts/${draft.id}`}
               className="underline"
             >
-              {draft.full_name}
+              {draft.fullName}
             </Link>
           </div>
           <div className="text-sm text-muted-foreground">
-            {draft.visibility} · default branch {draft.default_branch} · pushed{" "}
-            {formatDate(draft.pushed_at)}
+            {draft.visibility} · default branch {draft.defaultBranch} · pushed{" "}
+            {formatDate(draft.pushedAt)}
           </div>
           {draft.description && (
             <div className="text-sm text-muted-foreground">
               {draft.description}
             </div>
           )}
-          {draft.converted_project_id && (
+          {draft.convertedProjectId && (
             <div className="text-xs text-muted-foreground">
-              Converted · {formatDate(draft.converted_at)}
+              Converted · {formatDate(draft.convertedAt)}
             </div>
           )}
         </div>

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   getUserContext,
+  requireUserContext,
   supabaseGitHubConnectionsAdapter,
   supabaseProjectsAdapter,
   supabaseRepoDraftsAdapter,
@@ -59,12 +60,14 @@ const ACTIONS_BY_STATUS: Record<ProjectStatus, LifecycleAction[]> = {
 async function handleLifecycleAction(id: string, action: LifecycleAction) {
   "use server";
 
+  await requireUserContext();
   await applyLifecycleAction(supabaseProjectsAdapter, id, action);
 }
 
 async function handleLaunchAction(id: string) {
   "use server";
 
+  await requireUserContext();
   await applyLifecycleAction(supabaseProjectsAdapter, id, "launch");
 }
 
@@ -75,6 +78,7 @@ async function handleSnapshotAction(
 ) {
   "use server";
 
+  await requireUserContext();
   await applyLifecycleAction(supabaseProjectsAdapter, id, action, snapshot);
 }
 
@@ -86,6 +90,7 @@ async function handleOverrideRitual(
 ) {
   "use server";
 
+  await requireUserContext();
   await overrideActiveCap(
     supabaseProjectsAdapter,
     launchProjectId,
@@ -98,12 +103,14 @@ async function handleOverrideRitual(
 async function handleRestartCycle(id: string, nextAction: string) {
   "use server";
 
+  await requireUserContext();
   await restartArchivedProject(supabaseProjectsAdapter, id, nextAction);
 }
 
 async function handleDeleteProject(id: string) {
   "use server";
 
+  await requireUserContext();
   await deleteArchivedProject(supabaseProjectsAdapter, id);
 }
 

--- a/app/protected/page.tsx
+++ b/app/protected/page.tsx
@@ -1,4 +1,4 @@
-import type { ProjectStatus } from "@/lib/domain/project";
+import type { Project, ProjectStatus } from "@/lib/domain/project";
 import { DeleteArchivedProjectButton } from "@/components/delete-archived-project-button";
 import { FeedbackToast } from "@/components/feedback-toast";
 import { LifecycleActionButton } from "@/components/lifecycle-action-button";
@@ -14,9 +14,15 @@ import {
   type SnapshotInput,
 } from "@/components/snapshot-action-button";
 import { Button } from "@/components/ui/button";
-import { createClient } from "@/lib/supabase/server";
+import {
+  getUserContext,
+  supabaseGitHubConnectionsAdapter,
+  supabaseProjectsAdapter,
+  supabaseRepoDraftsAdapter,
+} from "@/lib/clients/supabase";
 import {
   applyLifecycleAction,
+  fetchProjects,
   type LifecycleAction,
   deleteArchivedProject,
   overrideActiveCap,
@@ -24,28 +30,10 @@ import {
 } from "@/lib/usecases/projects";
 import { getGitHubConnectionState } from "@/lib/usecases/github";
 import { fetchRepoDrafts } from "@/lib/usecases/github-drafts";
+import type { RepoDraft } from "@/lib/usecases/ports";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
-
-type ProjectRow = {
-  id: string;
-  name: string;
-  narrative_link: string | null;
-  why_now: string | null;
-  finish_definition: string | null;
-  status: ProjectStatus;
-  next_action: string;
-  start_date: string | null;
-  finish_date: string | null;
-  last_reviewed_at: string | null;
-};
-
-type DraftRow = {
-  id: string;
-  full_name: string;
-  converted_project_id: string | null;
-};
 
 const STATUS_LABELS: Record<ProjectStatus, string> = {
   active: "Active",
@@ -71,13 +59,13 @@ const ACTIONS_BY_STATUS: Record<ProjectStatus, LifecycleAction[]> = {
 async function handleLifecycleAction(id: string, action: LifecycleAction) {
   "use server";
 
-  await applyLifecycleAction(id, action);
+  await applyLifecycleAction(supabaseProjectsAdapter, id, action);
 }
 
 async function handleLaunchAction(id: string) {
   "use server";
 
-  await applyLifecycleAction(id, "launch");
+  await applyLifecycleAction(supabaseProjectsAdapter, id, "launch");
 }
 
 async function handleSnapshotAction(
@@ -87,7 +75,7 @@ async function handleSnapshotAction(
 ) {
   "use server";
 
-  await applyLifecycleAction(id, action, snapshot);
+  await applyLifecycleAction(supabaseProjectsAdapter, id, action, snapshot);
 }
 
 async function handleOverrideRitual(
@@ -98,33 +86,25 @@ async function handleOverrideRitual(
 ) {
   "use server";
 
-  await overrideActiveCap(launchProjectId, freezeProjectId, snapshot, decision);
+  await overrideActiveCap(
+    supabaseProjectsAdapter,
+    launchProjectId,
+    freezeProjectId,
+    snapshot,
+    decision,
+  );
 }
 
 async function handleRestartCycle(id: string, nextAction: string) {
   "use server";
 
-  await restartArchivedProject(id, nextAction);
+  await restartArchivedProject(supabaseProjectsAdapter, id, nextAction);
 }
 
 async function handleDeleteProject(id: string) {
   "use server";
 
-  await deleteArchivedProject(id);
-}
-
-async function fetchProjects(): Promise<ProjectRow[]> {
-  const supabase = await createClient();
-  const { data, error } = await supabase
-    .from("projects")
-    .select("*")
-    .order("start_date", { ascending: false, nullsFirst: false });
-
-  if (error) {
-    throw new Error(`Failed to load projects: ${error.message}`);
-  }
-
-  return data ?? [];
+  await deleteArchivedProject(supabaseProjectsAdapter, id);
 }
 
 function SystemStateHeader({
@@ -152,7 +132,7 @@ function SystemStateHeader({
   );
 }
 
-function groupProjects(projects: ProjectRow[]) {
+function groupProjects(projects: Project[]) {
   return {
     active: projects.filter((project) => project.status === "active"),
     frozen: projects.filter((project) => project.status === "frozen"),
@@ -166,7 +146,7 @@ function ProjectColumn({
   activeProjects,
 }: {
   status: ProjectStatus;
-  projects: ProjectRow[];
+  projects: Project[];
   activeProjects: ActiveProjectOption[];
 }) {
   const formatLastReviewed = (value: string | null) => {
@@ -204,10 +184,10 @@ function ProjectColumn({
                 </Link>
               </div>
               <div className="text-sm text-muted-foreground">
-                Next action: {project.next_action || "-"}
+                Next action: {project.nextAction || "-"}
               </div>
               <div className="text-xs text-muted-foreground">
-                {formatLastReviewed(project.last_reviewed_at)}
+                {formatLastReviewed(project.lastReviewedAt)}
               </div>
               {ACTIONS_BY_STATUS[project.status].length > 0 && (
                 <div className="mt-3 flex flex-wrap gap-2">
@@ -260,7 +240,7 @@ function ProjectColumn({
   );
 }
 
-function DraftColumn({ drafts }: { drafts: DraftRow[] }) {
+function DraftColumn({ drafts }: { drafts: RepoDraft[] }) {
   return (
     <section className="flex flex-col gap-3">
       <h2 className="text-xl font-semibold">Drafts</h2>
@@ -280,7 +260,7 @@ function DraftColumn({ drafts }: { drafts: DraftRow[] }) {
                   href={`/protected/github/drafts/${draft.id}`}
                   className="underline"
                 >
-                  {draft.full_name}
+                  {draft.fullName}
                 </Link>
               </div>
               <div className="text-sm text-muted-foreground">
@@ -295,14 +275,13 @@ function DraftColumn({ drafts }: { drafts: DraftRow[] }) {
 }
 
 async function ProjectBoard() {
-  const supabase = await createClient();
-  const { data } = await supabase.auth.getClaims();
+  const userContext = await getUserContext();
 
-  if (!data?.claims) {
+  if (!userContext) {
     redirect("/auth/login");
   }
 
-  const projects = await fetchProjects();
+  const projects = await fetchProjects(supabaseProjectsAdapter);
   const grouped = groupProjects(projects);
   const activeCount = grouped.active.length;
   const frozenCount = grouped.frozen.length;
@@ -310,11 +289,17 @@ async function ProjectBoard() {
   const activeProjectOptions = grouped.active.map((project) => ({
     id: project.id,
     name: project.name,
-    nextAction: project.next_action,
+    nextAction: project.nextAction,
   }));
-  const drafts = await fetchRepoDrafts();
-  const githubConnection = await getGitHubConnectionState();
-  const pendingDrafts = drafts.filter((draft) => !draft.converted_project_id);
+  const drafts = await fetchRepoDrafts(
+    supabaseRepoDraftsAdapter,
+    userContext,
+  );
+  const githubConnection = await getGitHubConnectionState(
+    supabaseGitHubConnectionsAdapter,
+    userContext,
+  );
+  const pendingDrafts = drafts.filter((draft) => !draft.convertedProjectId);
 
   return (
     <div className="flex flex-col gap-8">

--- a/app/protected/projects/[id]/page.tsx
+++ b/app/protected/projects/[id]/page.tsx
@@ -4,7 +4,11 @@ import { notFound, redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { createClient } from "@/lib/supabase/server";
+import {
+  getUserContext,
+  supabaseProjectSnapshotsAdapter,
+  supabaseProjectsAdapter,
+} from "@/lib/clients/supabase";
 import { fetchProjectSnapshots } from "@/lib/usecases/project-snapshots";
 import { fetchProjectById, updateProject } from "@/lib/usecases/projects";
 
@@ -39,7 +43,7 @@ async function saveProject(id: string, formData: FormData) {
     throw new Error("Name and next action are required.");
   }
 
-  await updateProject(id, {
+  await updateProject(supabaseProjectsAdapter, id, {
     name: nameValue.trim(),
     narrativeLink: normalizeOptional(formData.get("narrativeLink")),
     whyNow: normalizeOptional(formData.get("whyNow")),
@@ -51,20 +55,22 @@ async function saveProject(id: string, formData: FormData) {
 }
 
 async function ProjectDetail({ id }: { id: string }) {
-  const supabase = await createClient();
-  const { data } = await supabase.auth.getClaims();
+  const userContext = await getUserContext();
 
-  if (!data?.claims) {
+  if (!userContext) {
     redirect("/auth/login");
   }
 
-  const project = await fetchProjectById(id);
+  const project = await fetchProjectById(supabaseProjectsAdapter, id);
 
   if (!project) {
     notFound();
   }
 
-  const snapshots = await fetchProjectSnapshots(id);
+  const snapshots = await fetchProjectSnapshots(
+    supabaseProjectSnapshotsAdapter,
+    id,
+  );
   const statusLabel =
     project.status === "archived"
       ? project.finishDate
@@ -144,7 +150,7 @@ async function ProjectDetail({ id }: { id: string }) {
                   {snapshot.kind === "freeze"
                     ? "Freeze snapshot"
                     : "Finish snapshot"}{" "}
-                  - {formatDate(snapshot.created_at)}
+                  - {formatDate(snapshot.createdAt)}
                 </div>
                 <div className="font-medium">{snapshot.summary}</div>
                 {snapshot.label && (
@@ -152,14 +158,14 @@ async function ProjectDetail({ id }: { id: string }) {
                     Label: {snapshot.label}
                   </div>
                 )}
-                {snapshot.left_out && (
+                {snapshot.leftOut && (
                   <div className="text-sm text-muted-foreground">
-                    Left out: {snapshot.left_out}
+                    Left out: {snapshot.leftOut}
                   </div>
                 )}
-                {snapshot.future_note && (
+                {snapshot.futureNote && (
                   <div className="text-sm text-muted-foreground">
-                    Future note: {snapshot.future_note}
+                    Future note: {snapshot.futureNote}
                   </div>
                 )}
               </li>

--- a/app/protected/projects/[id]/page.tsx
+++ b/app/protected/projects/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   getUserContext,
+  requireUserContext,
   supabaseProjectSnapshotsAdapter,
   supabaseProjectsAdapter,
 } from "@/lib/clients/supabase";
@@ -36,6 +37,7 @@ function formatDate(value: string | null) {
 async function saveProject(id: string, formData: FormData) {
   "use server";
 
+  await requireUserContext();
   const nameValue = formData.get("name");
   const nextActionValue = formData.get("nextAction");
 

--- a/app/protected/projects/new/page.tsx
+++ b/app/protected/projects/new/page.tsx
@@ -4,7 +4,11 @@ import { redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { getUserContext, supabaseProjectsAdapter } from "@/lib/clients/supabase";
+import {
+  getUserContext,
+  requireUserContext,
+  supabaseProjectsAdapter,
+} from "@/lib/clients/supabase";
 import { createProject } from "@/lib/usecases/projects";
 
 function normalizeOptional(value: FormDataEntryValue | null): string | null {
@@ -19,6 +23,7 @@ function normalizeOptional(value: FormDataEntryValue | null): string | null {
 async function handleCreateProject(formData: FormData) {
   "use server";
 
+  await requireUserContext();
   const nameValue = formData.get("name");
   const nextActionValue = formData.get("nextAction");
 

--- a/app/protected/projects/new/page.tsx
+++ b/app/protected/projects/new/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { createClient } from "@/lib/supabase/server";
+import { getUserContext, supabaseProjectsAdapter } from "@/lib/clients/supabase";
 import { createProject } from "@/lib/usecases/projects";
 
 function normalizeOptional(value: FormDataEntryValue | null): string | null {
@@ -26,7 +26,7 @@ async function handleCreateProject(formData: FormData) {
     throw new Error("Name and next action are required.");
   }
 
-  await createProject({
+  await createProject(supabaseProjectsAdapter, {
     name: nameValue.trim(),
     narrativeLink: normalizeOptional(formData.get("narrativeLink")),
     whyNow: normalizeOptional(formData.get("whyNow")),
@@ -39,10 +39,9 @@ async function handleCreateProject(formData: FormData) {
 }
 
 async function NewProjectForm() {
-  const supabase = await createClient();
-  const { data } = await supabase.auth.getClaims();
+  const userContext = await getUserContext();
 
-  if (!data?.claims) {
+  if (!userContext) {
     redirect("/auth/login");
   }
 

--- a/components/review-gate.tsx
+++ b/components/review-gate.tsx
@@ -1,6 +1,7 @@
 import { REVIEW_STALE_DAYS } from "@/lib/domain/project";
 import {
   getUserContext,
+  requireUserContext,
   supabaseProjectsAdapter,
 } from "@/lib/clients/supabase";
 import {
@@ -46,6 +47,7 @@ async function applyReviewDecision(
 ) {
   "use server";
 
+  await requireUserContext();
   const reviewedAt = new Date().toISOString();
 
   if (action === "next_action") {

--- a/lib/clients/supabase/index.ts
+++ b/lib/clients/supabase/index.ts
@@ -2,3 +2,4 @@ export { supabaseProjectsAdapter } from "./projects-adapter";
 export { supabaseProjectSnapshotsAdapter } from "./project-snapshots-adapter";
 export { supabaseGitHubConnectionsAdapter } from "./github-connections-adapter";
 export { supabaseRepoDraftsAdapter } from "./repo-drafts-adapter";
+export { getUserContext, requireUserContext } from "./user-context";

--- a/lib/clients/supabase/projects-adapter.ts
+++ b/lib/clients/supabase/projects-adapter.ts
@@ -143,6 +143,20 @@ export const supabaseProjectsAdapter: ProjectsPort = {
     return toProject(data);
   },
 
+  async fetchProjects() {
+    const supabase = createServiceClient();
+    const { data, error } = await supabase
+      .from("projects")
+      .select("*")
+      .order("start_date", { ascending: false, nullsFirst: false });
+
+    if (error) {
+      throw new Error(`Failed to load projects: ${error.message}`);
+    }
+
+    return (data ?? []).map(toProject);
+  },
+
   async updateProject(id, updates) {
     const supabase = createServiceClient();
     const update = buildProjectUpdate(updates);
@@ -238,6 +252,9 @@ export const supabaseProjectsAdapter: ProjectsPort = {
       .single();
 
     if (error) {
+      if (error.message === "ACTIVE_CAP_REACHED") {
+        throw new Error("ACTIVE_CAP_REACHED");
+      }
       throw new Error(`Failed to launch project: ${error.message}`);
     }
 

--- a/lib/clients/supabase/user-context.ts
+++ b/lib/clients/supabase/user-context.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { createClient } from "@/lib/supabase/server";
+import type { UserContext } from "@/lib/usecases/ports";
+
+function getUserIdFromClaims(
+  claims: Record<string, unknown> | null | undefined,
+): string | null {
+  const sub = claims?.sub;
+  return typeof sub === "string" ? sub : null;
+}
+
+export async function getUserContext(): Promise<UserContext | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getClaims();
+
+  if (error || !data?.claims) {
+    return null;
+  }
+
+  const userId = getUserIdFromClaims(data.claims);
+  return userId ? { userId } : null;
+}
+
+export async function requireUserContext(): Promise<UserContext> {
+  const context = await getUserContext();
+
+  if (!context?.userId) {
+    throw new Error("Not authenticated.");
+  }
+
+  return context;
+}

--- a/lib/usecases/github-drafts.ts
+++ b/lib/usecases/github-drafts.ts
@@ -1,147 +1,55 @@
 import "server-only";
 
-import { createClient } from "../supabase/server";
-import type { Database } from "../supabase/types";
+import type {
+  RepoDraft,
+  RepoDraftConversionInput,
+  RepoDraftImport,
+  RepoDraftsPort,
+  UserContext,
+} from "@/lib/usecases/ports";
 
-type RepoDraftRow = Database["public"]["Tables"]["repo_drafts"]["Row"];
+export type { RepoDraftImport, RepoDraftConversionInput };
 
-export type RepoDraftImport = {
-  github_repo_id: number;
-  full_name: string;
-  html_url: string;
-  description: string | null;
-  visibility: string;
-  default_branch: string;
-  pushed_at: string | null;
-  topics?: string[] | null;
-};
+function requireUserContext(context: UserContext) {
+  if (!context.userId) {
+    throw new Error("Not authenticated.");
+  }
 
-function getUserIdFromClaims(claims: Record<string, unknown> | null | undefined) {
-  const sub = claims?.sub;
-  return typeof sub === "string" ? sub : null;
+  return context;
 }
 
 export async function upsertRepoDrafts(
+  port: RepoDraftsPort,
+  context: UserContext,
   drafts: RepoDraftImport[],
 ): Promise<number> {
   if (drafts.length === 0) {
     return 0;
   }
 
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.getClaims();
-
-  if (error || !data?.claims) {
-    throw new Error("Not authenticated.");
-  }
-
-  const userId = getUserIdFromClaims(data.claims);
-
-  if (!userId) {
-    throw new Error("Missing user id.");
-  }
-
-  const now = new Date().toISOString();
-  const payload = drafts.map((draft) => ({
-    user_id: userId,
-    github_repo_id: draft.github_repo_id,
-    full_name: draft.full_name,
-    html_url: draft.html_url,
-    description: draft.description,
-    visibility: draft.visibility,
-    default_branch: draft.default_branch,
-    pushed_at: draft.pushed_at,
-    topics: draft.topics ?? null,
-    imported_at: now,
-  }));
-
-  const { error: upsertError } = await supabase
-    .from("repo_drafts")
-    .upsert(payload, { onConflict: "user_id,github_repo_id" });
-
-  if (upsertError) {
-    throw new Error(`Failed to import drafts: ${upsertError.message}`);
-  }
-
-  return payload.length;
+  return port.upsertRepoDrafts(requireUserContext(context), drafts);
 }
 
-export async function fetchRepoDrafts(): Promise<RepoDraftRow[]> {
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.getClaims();
-
-  if (error || !data?.claims) {
-    throw new Error("Not authenticated.");
-  }
-
-  const { data: drafts, error: draftsError } = await supabase
-    .from("repo_drafts")
-    .select("*")
-    .order("imported_at", { ascending: false });
-
-  if (draftsError) {
-    throw new Error(`Failed to load drafts: ${draftsError.message}`);
-  }
-
-  return drafts ?? [];
+export async function fetchRepoDrafts(
+  port: RepoDraftsPort,
+  context: UserContext,
+): Promise<RepoDraft[]> {
+  return port.fetchRepoDrafts(requireUserContext(context));
 }
 
 export async function fetchRepoDraftById(
+  port: RepoDraftsPort,
+  context: UserContext,
   id: string,
-): Promise<RepoDraftRow | null> {
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.getClaims();
-
-  if (error || !data?.claims) {
-    throw new Error("Not authenticated.");
-  }
-
-  const { data: draft, error: draftError } = await supabase
-    .from("repo_drafts")
-    .select("*")
-    .eq("id", id)
-    .maybeSingle();
-
-  if (draftError) {
-    throw new Error(`Failed to load draft: ${draftError.message}`);
-  }
-
-  return draft ?? null;
+): Promise<RepoDraft | null> {
+  return port.fetchRepoDraftById(requireUserContext(context), id);
 }
 
-export type RepoDraftConversionInput = {
-  name: string;
-  nextAction: string;
-  finishDefinition?: string | null;
-};
-
 export async function convertRepoDraft(
+  port: RepoDraftsPort,
+  context: UserContext,
   id: string,
   input: RepoDraftConversionInput,
 ): Promise<string> {
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.getClaims();
-
-  if (error || !data?.claims) {
-    throw new Error("Not authenticated.");
-  }
-
-  const { data: projectResult, error: convertError } = await supabase
-    .rpc("convert_repo_draft_to_project", {
-      draft_id: id,
-      project_name: input.name.trim(),
-      next_action: input.nextAction.trim(),
-      finish_definition: input.finishDefinition ?? null,
-    })
-    .single();
-
-  if (convertError) {
-    throw new Error(`Failed to convert draft: ${convertError.message}`);
-  }
-
-  if (!projectResult?.project_id) {
-    throw new Error("Draft conversion failed.");
-  }
-
-  return projectResult.project_id;
+  return port.convertRepoDraft(requireUserContext(context), id, input);
 }

--- a/lib/usecases/github.ts
+++ b/lib/usecases/github.ts
@@ -1,107 +1,38 @@
 import "server-only";
 
-import { createClient, createServiceClient } from "../supabase/server";
-import type { Database } from "../supabase/types";
+import type {
+  GitHubConnection,
+  GitHubConnectionsPort,
+  GitHubConnectionState,
+  UpsertGitHubConnectionInput,
+  UserContext,
+} from "@/lib/usecases/ports";
 
-type GitHubConnectionRow =
-  Database["public"]["Tables"]["github_connections"]["Row"];
-
-export type GitHubConnectionState = {
-  connected: boolean;
-  githubLogin?: string;
-};
-
-function getUserIdFromClaims(claims: Record<string, unknown> | null | undefined) {
-  const sub = claims?.sub;
-  return typeof sub === "string" ? sub : null;
-}
-
-export async function getGitHubConnectionState(): Promise<GitHubConnectionState> {
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.getClaims();
-
-  if (error || !data?.claims) {
+export async function getGitHubConnectionState(
+  port: GitHubConnectionsPort,
+  context: UserContext,
+): Promise<GitHubConnectionState> {
+  if (!context.userId) {
     return { connected: false };
   }
 
-  const userId = getUserIdFromClaims(data.claims);
-
-  if (!userId) {
-    return { connected: false };
-  }
-
-  const { data: connection, error: connectionError } = await supabase
-    .rpc("get_github_connection_state")
-    .single();
-
-  if (connectionError) {
-    throw new Error(`Failed to load GitHub connection: ${connectionError.message}`);
-  }
-
-  return connection?.connected
-    ? { connected: true, githubLogin: connection.github_login ?? undefined }
-    : { connected: false };
+  return port.getConnectionState(context);
 }
 
-export async function getGitHubAccessToken(): Promise<string | null> {
-  const supabase = await createClient();
-  const { data, error } = await supabase.auth.getClaims();
-
-  if (error || !data?.claims) {
+export async function getGitHubAccessToken(
+  port: GitHubConnectionsPort,
+  context: UserContext,
+): Promise<string | null> {
+  if (!context.userId) {
     return null;
   }
 
-  const userId = getUserIdFromClaims(data.claims);
-
-  if (!userId) {
-    return null;
-  }
-
-  const serviceClient = createServiceClient();
-  const { data: connection, error: connectionError } = await serviceClient
-    .from("github_connections")
-    .select("access_token")
-    .eq("user_id", userId)
-    .maybeSingle();
-
-  if (connectionError) {
-    throw new Error(`Failed to load GitHub token: ${connectionError.message}`);
-  }
-
-  return connection?.access_token ?? null;
+  return port.getAccessToken(context);
 }
-
-type UpsertGitHubConnectionInput = {
-  userId: string;
-  githubUserId: number;
-  githubLogin: string;
-  accessToken: string;
-};
 
 export async function upsertGitHubConnection(
+  port: GitHubConnectionsPort,
   input: UpsertGitHubConnectionInput,
-): Promise<GitHubConnectionRow> {
-  const supabase = createServiceClient();
-  const now = new Date().toISOString();
-
-  const { data, error } = await supabase
-    .from("github_connections")
-    .upsert(
-      {
-        user_id: input.userId,
-        github_user_id: input.githubUserId,
-        github_login: input.githubLogin,
-        access_token: input.accessToken,
-        updated_at: now,
-      },
-      { onConflict: "user_id" },
-    )
-    .select("*")
-    .single();
-
-  if (error) {
-    throw new Error(`Failed to store GitHub connection: ${error.message}`);
-  }
-
-  return data;
+): Promise<GitHubConnection> {
+  return port.upsertConnection(input);
 }

--- a/lib/usecases/ports/projects.ts
+++ b/lib/usecases/ports/projects.ts
@@ -30,6 +30,7 @@ export interface ProjectsPort {
     input: NewProjectInput,
     options: { enforceActiveCap: boolean; maxActive: number },
   ): Promise<Project>;
+  fetchProjects(): Promise<Project[]>;
   updateProject(id: string, updates: UpdateProjectInput): Promise<Project>;
   fetchProjectById(id: string): Promise<Project | null>;
   freezeProjectWithSnapshot(

--- a/lib/usecases/project-snapshots.ts
+++ b/lib/usecases/project-snapshots.ts
@@ -1,28 +1,17 @@
 import "server-only";
 
-import { createClient } from "../supabase/server";
-import type { Database } from "../supabase/types";
-
-export type ProjectSnapshotRow =
-  Database["public"]["Tables"]["project_snapshots"]["Row"];
+import type {
+  ProjectSnapshot,
+  ProjectSnapshotsPort,
+} from "@/lib/usecases/ports";
 
 export async function fetchProjectSnapshots(
+  port: ProjectSnapshotsPort,
   projectId: string,
-): Promise<ProjectSnapshotRow[]> {
+): Promise<ProjectSnapshot[]> {
   if (!projectId) {
     throw new Error("Project id is required.");
   }
 
-  const supabase = await createClient();
-  const { data, error } = await supabase
-    .from("project_snapshots")
-    .select("*")
-    .eq("project_id", projectId)
-    .order("created_at", { ascending: false });
-
-  if (error) {
-    throw new Error(`Failed to load snapshots: ${error.message}`);
-  }
-
-  return data ?? [];
+  return port.fetchProjectSnapshots(projectId);
 }


### PR DESCRIPTION
## What/Why
- Refactor use-cases to depend on persistence ports and wire Supabase adapters at call sites.
- Add minimal wiring so UI/data flows use use-cases + adapters instead of direct Supabase queries.
- Keep auth flows on Supabase; add user context helper for server-side auth checks.

## How to test
- Manual smoke: login, dashboard loads, lifecycle actions, GitHub import + drafts list + conversion, project detail updates.

## Risks
- Medium: refactor touches multiple server components and use-cases.

Closes #34