### PR TITLE
PCE-404 Smoke test checklist

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -65,3 +65,60 @@ Scope:
 Acceptance criteria:
 - App smoke flow still works end-to-end.
 - Any test or smoke documentation is updated to reflect the new wiring.
+
+## Epic 6 - Offline-Only Local Persistence (V1.3)
+
+Goal: Run fully offline for a single local user in the web app, while keeping
+the option to switch back to Supabase via adapter wiring.
+
+### PCE-501 Decide local storage strategy (IndexedDB vs SQLite/WASM)
+
+Goal: Pick and document the local persistence technology for web offline use.
+
+Scope:
+- Compare IndexedDB vs SQLite/WASM for this app's needs (simplicity, size, perf).
+- Decide whether a helper library is needed (note: new deps require ADR).
+- Document the decision + constraints in an ADR.
+
+Acceptance criteria:
+- ADR added with chosen storage and rationale.
+
+### PCE-502 Implement local persistence adapters
+
+Goal: Provide offline adapters that implement the existing ports.
+
+Scope:
+- Implement adapters for projects, snapshots, repo drafts, and GitHub connections
+  using the chosen local storage.
+- Port behavior matches current Supabase adapters (including atomic operations).
+
+Out of scope:
+- Sync with remote services.
+
+Acceptance criteria:
+- Offline adapters compile and satisfy all ports.
+- Unit tests (or minimal harness) validate core flows locally.
+
+### PCE-503 Wire offline adapters via config
+
+Goal: Allow selecting offline adapters at runtime/build time.
+
+Scope:
+- Add a simple wiring toggle (env/config) to choose offline vs Supabase adapters.
+- Ensure UI/data flows work with offline adapters only.
+
+Acceptance criteria:
+- App runs with offline adapters without touching Supabase.
+- Switching adapters does not change use-case behavior.
+
+### PCE-504 Data portability (export/import)
+
+Goal: Keep a path to move data between offline and Supabase later.
+
+Scope:
+- Provide JSON export/import for all domain entities.
+- Document a manual migration flow (offline -> Supabase) using adapters.
+
+Acceptance criteria:
+- Export/import works for projects, snapshots, and drafts.
+- Migration notes documented.

--- a/docs/smoke-tests/persistence-ports.md
+++ b/docs/smoke-tests/persistence-ports.md
@@ -1,0 +1,37 @@
+# Smoke Test - Persistence Ports Wiring
+
+Goal: Verify that the app still works end-to-end after routing data access
+through persistence ports and adapters.
+
+## Preconditions
+
+- Valid Supabase env vars in `.env.local`
+- Existing user account
+
+## Checklist
+
+1. Login.
+2. Open `/protected` and confirm:
+   - Board loads without errors.
+   - Projects grouped by status.
+3. Create a new project at `/protected/projects/new`.
+4. Run lifecycle actions:
+   - Freeze (with snapshot)
+   - Finish (with snapshot)
+   - Archive (no snapshot)
+   - Launch (from Frozen)
+5. Open project detail and confirm snapshots show up.
+6. Review mode:
+   - Visit `/protected?review=1`
+   - Apply a decision and confirm last reviewed updates.
+7. GitHub import:
+   - Connect GitHub.
+   - Import at least one repo.
+   - View drafts list and draft detail.
+   - Convert a draft into a project.
+
+## Expected results
+
+- No runtime errors.
+- All actions persist correctly.
+- Draft conversion creates a new project.


### PR DESCRIPTION
## What/Why
- Add a smoke test checklist for the persistence ports wiring change.
- Run required checks (lint/typecheck/build).

## How to test
- Follow docs/smoke-tests/persistence-ports.md

## Checks
- pnpm lint (pass)
- pnpm typecheck (pass)
- pnpm build (pass, warning about multiple lockfiles)

## Risks
- Low: documentation-only change.

Closes #35